### PR TITLE
Add shebang

### DIFF
--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 #
 #  OS X Collector


### PR DESCRIPTION
Similar to [sivel/speedtest_cli.py](https://github.com/sivel/speedtest-cli/blob/master/speedtest_cli.py), it seems nicer to not have to invoke Python directly.
