### PR TITLE
Improve kext section: Look for kext in /Library/Extensions and CFBundleIdentifier to output for plists

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ Collects basic information about the system:
 
 ### `kext`
 
-Collects the Kernel extensions from `/System/Library/Extensions`.
+Collects the Kernel extensions from:
+- `/System/Library/Extensions`
+- '/Library/Extensions'
 
 ### Startup
 

--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -622,6 +622,7 @@ class Collector(object):
                 file_path = pathjoin(sub_dir_path, cfbundle_executable_path, cfbundle_executable)
                 file_info = _get_file_info(file_path)
                 file_info['osxcollector_plist_path'] = plist_path
+                file_info['osxcollector_bundle_id'] = plist.get('CFBundleIdentifier', '')
                 Logger.log_dict(file_info)
 
     def _log_startup_items(self, dir_path):
@@ -922,7 +923,13 @@ class Collector(object):
 
     def _collect_kext(self):
         """Log the Kernel extensions"""
-        self._log_packages_in_dir(pathjoin(ROOT_PATH, 'System/Library/Extensions/'))
+        kext_paths = [
+            'System/Library/Extensions',
+            'Library/Extensions'
+        ]
+
+        for kext_path in kext_paths:
+            self._log_packages_in_dir(pathjoin(ROOT_PATH, kext_path))
 
     def _collect_accounts(self):
         """Log users's accounts"""

--- a/tests/osxcollector_collector_test.py
+++ b/tests/osxcollector_collector_test.py
@@ -81,7 +81,8 @@ class CollectorTestCase(T.TestCase):
 
     def test_log_packages_in_dir(self):
         expected = {
-            'osxcollector_plist_path': 'tests/data/packages/Digital Hub Scripting.osax/Contents/Info.plist'
+            'osxcollector_plist_path': 'tests/data/packages/Digital Hub Scripting.osax/Contents/Info.plist',
+            'osxcollector_bundle_id': 'com.apple.osax.digihub'
         }
         expected = self._really_expected_file_info(expected)
 


### PR DESCRIPTION
I noticed some of the kext on my machine were not in the oscollector output.
I also wanted to be able to more easily see the identifier for a kext.

Tests continue to pass, sample run seems legits.
