### PR TITLE
Fixed spaces for tabs in example configuration file

### DIFF
--- a/osxcollector.yaml.example
+++ b/osxcollector.yaml.example
@@ -4,7 +4,7 @@ OpenDNSFilter:
 
 # The VTHashesFilter requires an API key for VirusTotal
 VTHashesFilter:
-	api_key: "ADD YOUR KEY"
+    api_key: "ADD YOUR KEY"
 
 # The BlacklistFilter allows for multiple blacklists to be compared against at once
 # Each blacklists requires:


### PR DESCRIPTION
There was a tab instead of spaces that caused the YAML parser to fail on the configuration file taken directly from the example.
