### PR TITLE
Fix bug in FindDomainFilter where using some domains were not found

### DIFF
--- a/osxcollector/output_filters/find_domains.py
+++ b/osxcollector/output_filters/find_domains.py
@@ -45,14 +45,15 @@ class FindDomainsFilter(OutputFilter):
             key: A string key associated with the value.
         """
         if isinstance(val, basestring):
+            if key in self.HOST_KEYS:
+                self._add_domain(val)
+                return
             if -1 != self.SCHEMES.search(val):
                 # Sometimes values are complex strings, like JSON or pickle encoded stuff.
                 # Try splitting the string on non-URL related punctuation
                 for maybe_url in re.split('[ \'\(\)\"\[\]\{\}\;\n\t#@\^&\*=]+', val):
                     domain = self._url_to_domain(maybe_url)
                     self._add_domain(domain)
-            elif key in ['host', 'host_key']:
-                self._add_domain(domain)
         elif isinstance(val, list):
             for elem in val:
                 self._look_for_domains(elem)
@@ -93,6 +94,7 @@ class FindDomainsFilter(OutputFilter):
             pass
 
     SCHEMES = re.compile('((https?)|ftp)')
+    HOST_KEYS = ['host', 'host_key', 'baseDomain']
 
 
 def expand_domain(domain):

--- a/tests/output_filters/domains_test.py
+++ b/tests/output_filters/domains_test.py
@@ -88,6 +88,16 @@ class DomainsFilterTest(T.TestCase):
         ]
         self._test_look_for_domains(blob, expected)
 
+    def test_special_keys_domain(self):
+        blob = {'host': 'www.example.com'}
+        expected = ['www.example.com', 'example.com']
+        self._test_look_for_domains(blob, expected)
+
+    def test_special_keys_url(self):
+        blob = {'host': 'https://www.example.com'}
+        expected = ['www.example.com', 'example.com']
+        self._test_look_for_domains(blob, expected)
+
     def _test_look_for_domains(self, blob, domains):
         output = self._output_filter.filter_line(blob)
         T.assert_equal(sorted(output.get('osxcollector_domains', None)), sorted(domains))


### PR DESCRIPTION
The ordering in `FindDomainsFilter._look_for_domains` was a bit off. The search for a something starting with `http|ftp` would happen, fail, and game over for finding a domain.

Instead, try to find a special key indicating this is a domain, if that fails, then look for  `http|ftp`.

Added tests to keep this working.
