### PR TITLE
Added get_file_reports in VT API module and changed API call in lookup_h...

### DIFF
--- a/osxcollector/output_filters/virustotal/api.py
+++ b/osxcollector/output_filters/virustotal/api.py
@@ -23,6 +23,21 @@ class VirusTotalApi(object):
 
         return [response.json() for response in responses]
 
+    def get_file_reports(self, resources):
+        """Retrieves the most recent report on a given sample (md5/sha1/sha256 hash).
+
+        Args:
+            resources: list of md5/sha1/sha256 hashes.
+            Each list element can be also a CSV list made up of a combination of hashes
+            (up to 4 items with the standard request rate), this allows to perform
+            a batch request with one single call.
+        Returns:
+            dict
+        """
+        params = [{"resource": resource, 'apikey': self._api_key} for resource in resources]
+        responses = self._make_requests(self.BASE_DOMAIN + 'file/report', params)
+        return dict([(resource, response) for resource, response in zip(resources, responses)])
+
     def get_domain_reports(self, domains):
         params = [{"domain": domain, 'apikey': self._api_key} for domain in domains]
         responses = self._make_requests(self.BASE_DOMAIN + 'domain/report', params)

--- a/osxcollector/output_filters/virustotal/lookup_hashes.py
+++ b/osxcollector/output_filters/virustotal/lookup_hashes.py
@@ -22,7 +22,7 @@ class LookupHashesFilter(ThreatFeedFilter):
     def _lookup_iocs(self):
         """Caches the OpenDNS info for a set of domains"""
         vt = VirusTotalApi(self._api_key)
-        reports = vt.get_domain_reports(self._all_iocs)
+        reports = vt.get_file_reports(self._all_iocs)
 
         for md5 in reports.keys():
             report = reports[md5]


### PR DESCRIPTION
The VT API call to look up the hashes was using `domain/report` endpoint which only works for the domains.
Now `api.py` contains a new method to look up the hashes: `get_file_reports`. This method is used by `lookup_hashes.py` instead of `get_domain_reports`.

_Note:_
VT API endpoint `file/report` accepts `resource` parameter which can be a single hash or a list of hashes, in CSV format. We are not using that so far but it could speed up the requests by batching them.
