### PR TITLE
Fix Issue 44 - better compare of filenames for ShadowServer

### DIFF
--- a/osxcollector/output_filters/shadowserver/lookup_hashes.py
+++ b/osxcollector/output_filters/shadowserver/lookup_hashes.py
@@ -4,6 +4,8 @@
 #
 # LookupHashesFilter uses ShadowServer to lookup the values in 'sha1' and add 'osxcollector_shadowserver' key.
 #
+import os.path
+
 from osxcollector.output_filters.base_filters.output_filter import run_filter
 from osxcollector.output_filters.base_filters. \
     threat_feed import ThreatFeedFilter
@@ -39,9 +41,8 @@ class LookupHashesFilter(ThreatFeedFilter):
         Returns:
             boolean
         """
-        if blob.get('file_path', '').endswith(threat_info.get('filename', '')):
-            return True
-        return False
+        blob_filename = os.path.split(blob.get('file_path', ''))[-1]
+        return blob_filename == threat_info.get('filename', '')
 
 
 def main():

--- a/osxcollector/output_filters/virustotal/lookup_urls.py
+++ b/osxcollector/output_filters/virustotal/lookup_urls.py
@@ -22,8 +22,8 @@ class LookupURLsFilter(ThreatFeedFilter):
     def __init__(self, lookup_when=None):
         lookup_when_url_scheme_matches = self._generate_lookup_when(lookup_when)
         super(LookupURLsFilter, self).__init__('LSQuarantineDataURLString', 'osxcollector_vturl',
-                                                 lookup_when=lookup_when_url_scheme_matches,
-                                                 name_of_api_key='virustotal')
+                                               lookup_when=lookup_when_url_scheme_matches,
+                                               name_of_api_key='virustotal')
 
     def _generate_lookup_when(self, only_lookup_when):
         """Generates functions that checks whether the blob contains a valid URL

--- a/tests/output_filters/shadowserver/lookup_hashes_test.py
+++ b/tests/output_filters/shadowserver/lookup_hashes_test.py
@@ -64,3 +64,11 @@ class LookupHashesFilterTest(RunFilterTest):
         T.assert_equal(1, len(output_blobs))
 
         T.assert_not_in('osxcollector_shadowserver', output_blobs[0])
+
+    def test_partial_filename(self):
+        """Change the filename and don't match"""
+        self._known_sha1_input[0]['file_path'] = '/System/Library/Extensions/System.kext/PlugIns/Libkern.kext/Not_Quite_Libkern'
+        output_blobs = self.run_test(LookupHashesFilter, self._known_sha1_input)
+        T.assert_equal(1, len(output_blobs))
+
+        T.assert_not_in('osxcollector_shadowserver', output_blobs[0])


### PR DESCRIPTION
Use `os.path.split` to get the filename out of a path.
Fixes #44 