### PR TITLE
Utf8 encoding

### DIFF
--- a/osxcollector/output_filters/analyze.py
+++ b/osxcollector/output_filters/analyze.py
@@ -268,7 +268,11 @@ class _VeryReadableOutputFilter(OutputFilter):
     def _write(self, msg, color=END_COLOR):
         if not self._monochrome:
             sys.stdout.write(color)
-        sys.stdout.write(msg)
+        try:
+            sys.stdout.write(msg.encode("utf-8", errors="ignore"))
+        except UnicodeDecodeError:
+            # TODO: add optional debug information about the error
+            sys.stdout.write(msg)
         if not self._monochrome:
             sys.stdout.write(self.END_COLOR)
 

--- a/osxcollector/output_filters/opendns/lookup_domains.py
+++ b/osxcollector/output_filters/opendns/lookup_domains.py
@@ -112,7 +112,7 @@ class LookupDomainsFilter(ThreatFeedFilter):
                     'domain': domain,
                     'categorization': categorized[domain],
                     'security': self._trim_security_result(security[domain]),
-                    'link': 'https://investigate.opendns.com/domain-view/name/{0}/view'.format(domain)
+                    'link': 'https://investigate.opendns.com/domain-view/name/{0}/view'.format(domain.encode('utf-8', errors='ignore'))
                 }
 
         return threat_info

--- a/osxcollector/output_filters/util/domains.py
+++ b/osxcollector/output_filters/util/domains.py
@@ -20,10 +20,10 @@ def expand_domain(domain):
 
     if extraction.subdomain:
         subdomain = '.'.join(extraction)
-        yield subdomain.encode('utf-8', errors='ignore')
+        yield subdomain
 
     fulldomain = '.'.join(extraction[1:])
-    yield fulldomain.encode('utf-8', errors='ignore')
+    yield fulldomain
 
 
 def clean_domain(unclean_domain):

--- a/tests/output_filters/util/domains_test.py
+++ b/tests/output_filters/util/domains_test.py
@@ -45,6 +45,9 @@ class ExpandDomainTest(T.TestCase):
     def test_complex_subdomain(self):
         self._test_expand_domain('www.foo.bar.whiz.example.com', ['example.com', 'www.foo.bar.whiz.example.com'])
 
+    def test_unicode_subdomain(self):
+        self._test_expand_domain('www.jobbörse.com', ['www.jobbörse.com', 'jobbörse.com'])
+
     def _test_expand_domain(self, initial_domain, expected):
         expanded = list(expand_domain(initial_domain))
         T.assert_equal(sorted(expanded), sorted(expected))


### PR DESCRIPTION
This should fix the issues with domain names containing non-ascii characters.
Also related issue appeared for the output elements that were not domains, but contained non-ascii characters (titles, descriptions). I have added encode call there as well as for the OpenDNS link that had issues with handling the domains containing non-ascii characters.