### PR TITLE
Added FDE Status to System Info

### DIFF
--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -883,7 +883,7 @@ class Collector(object):
                     debugbreak()
                     Logger.log_exception(section_e, message='failed section')
 
-    def _is_fde_enabled():
+    def _is_fde_enabled(self):
         """Gathers the Full Disc Encryption status of the system."""
 
         fde_status = os.popen('fdesetup status').read()
@@ -1132,7 +1132,7 @@ class Collector(object):
 
         # Basic OS info
         sysname, nodename, release, version, machine = os.uname()
-        fde = _is_fde_enabled()
+        fde = self._is_fde_enabled()
         record = {
             'sysname': sysname,
             'nodename': nodename,

--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -64,7 +64,6 @@ def debugbreak():
 HomeDir = namedtuple('HomeDir', ['user_name', 'path'])
 """A simple tuple for storing info about a user"""
 
-
 def _get_homedirs():
     """Return a list of HomeDir objects
 
@@ -884,6 +883,16 @@ class Collector(object):
                     debugbreak()
                     Logger.log_exception(section_e, message='failed section')
 
+    def _is_fde_enabled():
+        """Gathers the Full Disc Encryption status of the system."""
+
+        fde_status = os.popen('fdesetup status').read()
+
+        if "On" in fde_status:
+            return True
+        else:
+            return False
+
     def _foreach_homedir(func):
         """A decorator to ensure a method is called for each user's homedir.
 
@@ -1123,12 +1132,14 @@ class Collector(object):
 
         # Basic OS info
         sysname, nodename, release, version, machine = os.uname()
+        fde = _is_fde_enabled()
         record = {
             'sysname': sysname,
             'nodename': nodename,
             'release': release,
             'version': version,
-            'machine': machine
+            'machine': machine,
+            'fde': fde
         }
         Logger.log_dict(record)
 


### PR DESCRIPTION
When triaging a machine, especially one that may have been involved in a physical access issue, knowing the status of OSX Full Disk Encryption is useful. 

![jmopvr7](https://cloud.githubusercontent.com/assets/44774/6088109/19600030-ae21-11e4-9e0d-2876156222ff.gif)

So with this PR that information is automatically added.