### PR TITLE
Pass arguments to RelatedFilesFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,8 @@ This filter is great for figuring out how `evil_invoice.pdf` landed up on a mach
 Run it as:
 ```shell
 $ cat CanisAsp.json | \
-    python -m osxcollector.output_filters.related_files
+    python -m osxcollector.output_filters.related_files -f '/foo/bar/baz' \
+                                                        -f 'dingle'
 ```
 
 To see related lines try:

--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -64,6 +64,7 @@ def debugbreak():
 HomeDir = namedtuple('HomeDir', ['user_name', 'path'])
 """A simple tuple for storing info about a user"""
 
+
 def _get_homedirs():
     """Return a list of HomeDir objects
 

--- a/osxcollector/output_filters/firefox/find_extensions.py
+++ b/osxcollector/output_filters/firefox/find_extensions.py
@@ -22,7 +22,7 @@ class FindExtensionsFilter(OutputFilter):
         self._new_lines = []
 
     def filter_line(self, blob):
-        if 'chrome' != blob.get('osxcollector_section') and 'json_files' != blob.get('osxcollector_subsection'):
+        if 'firefox' != blob.get('osxcollector_section') and 'json_files' != blob.get('osxcollector_subsection'):
             return blob
 
         if blob.get('osxcollector_json_file') not in ['addons.json', 'extensions.json']:

--- a/osxcollector/output_filters/related_files.py
+++ b/osxcollector/output_filters/related_files.py
@@ -3,11 +3,13 @@
 # RelatedFilesFilter finds files related to specific terms or file names.
 #
 import os.path
+from argparse import ArgumentParser
 
 import simplejson
 
 from osxcollector.osxcollector import DictUtils
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
+from osxcollector.output_filters.base_filters.output_filter import run_filter
 
 
 class RelatedFilesFilter(OutputFilter):
@@ -19,7 +21,7 @@ class RelatedFilesFilter(OutputFilter):
     is discarded.
     """
 
-    def __init__(self, when, initial_terms=None):
+    def __init__(self, when=None, initial_terms=None):
         super(RelatedFilesFilter, self).__init__()
         self._all_blobs = list()
         self._terms = set()
@@ -39,7 +41,7 @@ class RelatedFilesFilter(OutputFilter):
     def filter_line(self, blob):
         self._all_blobs.append(blob)
 
-        if self._when(blob):
+        if self._when and self._when(blob):
             for key in self.FILE_NAME_KEYS:
                 val = DictUtils.get_deep(blob, key)
                 if val:
@@ -114,3 +116,16 @@ class RelatedFilesFilter(OutputFilter):
         'versions',
         'var'
     ]
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('-f', '--file-term', dest='file_terms', default=[], action='append',
+                        help='[OPTIONAL] Suspicious terms to use in pivoting through file names.  May be specified more than once.')
+    args = parser.parse_args()
+
+    run_filter(RelatedFilesFilter(initial_terms=args.file_terms))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
So argument passing to individual filters is kinda messed up. I think it needs a reworking.
But this is a quick unblock till I can get some time on Thursday to improve stuff.