### PR TITLE
Arg parsing update

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,16 +306,22 @@ Using combinations of these basic filters, an analyst can figure out a lot of wh
 
 FindDomainsFilter isn't too useful on it's own but it's super powerful when chained with filters like `FindBlacklistedFilter` and or `osxcollector.output_filters.virustotal.lookup_domains.LookupDomainsFilter`.
 
-Running this will add the domains found by osxcollector to the output:
+To run and see lines where domains have been added try:
 ```shell
-$ cat RomeoCredible.json | \
-    python -m osxcollector.output_filters.find_domains
+$ python -m osxcollector.output_filters.find_domains -i RomeoCredible.json | \
+    jq 'select(has("osxcollector_domains"))'
 ```
 
-To see lines where domains have been added try:
+Usage:
 ```shell
-$ cat RomeoCredible.json | \
-    python -m osxcollector.output_filters.find_domains | jq 'select(has("osxcollector_domains"))'
+$ python -m osxcollector.output_filters.find_domains -h
+usage: find_domains.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ##### FindBlacklistedFilter
@@ -330,24 +336,24 @@ Configuration Keys:
 * `blacklist_is_regex`: [REQUIRED] should the values in the blacklist file be treated as regex
 * `blacklist_is_domains`: [OPTIONAL] interpret values as domains and do some smart regex and subdomain stuff with them.
 
-Running this will tag blacklisted items in the output:
-```shell
-$ cat RiddlerBelize.json | \
-    python -m osxcollector.output_filters.find_blacklisted
-```
-
-To see lines matching a blacklist try:
-```shell
-$ cat RiddlerBelize.json | \
-    python -m osxcollector.output_filters.find_blacklisted | jq 'select(has("osxcollector_blacklist"))'
-```
 If you want to find blacklisted domains, you will have to use the find_domains filter to pull the domains out first. To see lines matching a specific blacklist named `domains` try:
 ```shell
-$ cat RiddlerBelize.json | \
-    python -m osxcollector.output_filters.find_domains | \
+$ python -m osxcollector.output_filters.find_domains -i RiddlerBelize.json | \
     python -m osxcollector.output_filters.find_blacklisted | \
     jq 'select(has("osxcollector_blacklist")) | \
-    select(.osxcollector_blacklist | keys[] | contains("domains"))'
+        select(.osxcollector_blacklist | keys[] | contains("domains"))'
+```
+
+Usage:
+```shell
+$ python -m osxcollector.output_filters.find_blacklisted -h
+usage: find_blacklisted.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ##### RelatedFilesFilter
@@ -355,85 +361,125 @@ $ cat RiddlerBelize.json | \
 
 This filter is great for figuring out how `evil_invoice.pdf` landed up on a machine. It'll find browser history, quarantines, email messages, etc. related to a file.
 
-Run it as:
+To run and see related lines try:
 ```shell
-$ cat CanisAsp.json | \
-    python -m osxcollector.output_filters.related_files -f '/foo/bar/baz' \
-                                                        -f 'dingle'
+$ python -m osxcollector.output_filters.related_files -i CanisAsp.json \
+         -f '/foo/bar/baz' -f 'dingle' | \
+    jq 'select(has("osxcollector_related")) | \
+        select(.osxcollector_related | keys[] | contains("files"))'
 ```
 
-To see related lines try:
+Usage:
 ```shell
-$ jq 'select(has("osxcollector_related")) |
-      select(.osxcollector_related | keys[] | contains("files"))'
+$ python -m osxcollector.output_filters.related_files -h
+usage: related_files.py [-h] [-f FILE_TERMS] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
+
+RelatedFilesFilter:
+  -f FILE_TERMS, --file-term FILE_TERMS
+                        [OPTIONAL] Suspicious terms to use in pivoting through
+                        file names. May be specified more than once.
 ```
 
 ##### ChromeHistoryFilter
 `osxcollector.output_filters.chrome.sort_history.SortHistoryFilter` builds a really nice Chrome browser history sorted in descending time order. This output is comparable to looking at the history tab in the browser but actually contains _more_ info. The `core_transition` and `page_transition` keys explain whether the user got to the page by clicking a link, through a redirect, a hidden iframe, etc.
 
-Running this will output json with the tags added by the filter:
+To run and see Chrome browser history:
 ```shell
-$ cat PrinceCrazy.json | \
-    python -m osxcollector.output_filters.chrome.sort_history
-```
-
-To see Chrome browser history:
-```shell
-$ cat PrinceCrazy.json | \
-    python -m osxcollector.output_filters.chrome.sort_history | \
+$ python -m osxcollector.output_filters.chrome.sort_history -i SirCray.json | \
     jq 'select(.osxcollector_browser_history=="chrome")'
 ```
 
 This is great mixed with a grep in a certain time window, like maybe the 5 minutes before that hinky download happened.
+```shell
+$ python -m osxcollector.output_filters.chrome.sort_history -i SirCray.json | \
+    jq -c 'select(.osxcollector_browser_history=="chrome")' | \
+    egrep '2015-02-02 20:3[2-6]'
+```
+
+Usage:
+```shell
+$ python -m osxcollector.output_filters.chrome.sort_history -h
+usage: sort_history.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
+```
 
 ##### FirefoxHistoryFilter
 `osxcollector.output_filters.firefox.sort_history.SortHistoryFilter` builds a really nice Firefox browser history sorted in descending time order. It's a lot like the `ChromeHistoryFilter`.
 
-Run it as:
+To run and see Firefox browser history:
 ```shell
-$ cat CousingLobe.json | \
-    python -m osxcollector.output_filters.firefox.sort_history
+$ python -m osxcollector.output_filters.firefox.sort_history \
+         -i CousingLobe.json | \
+    jq 'select(.osxcollector_browser_history=="firefox")'
 ```
 
-To see Firefox browser history:
+Usage:
 ```shell
-$ cat CousingLobe.json | \
-    python -m osxcollector.output_filters.firefox.sort_history | \
-    jq 'select(.osxcollector_browser_history=="firefox")'
+$ python -m osxcollector.output_filters.firefox.sort_history -h
+usage: sort_history.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ##### ChromeExtensionsFilter
 `osxcollector.output_filters.chrome.find_extensions.FindExtensionsFilter` looks for extensions in the Chrome JSON files.
 
-Run it as:
+To run and see Chrome extensions:
 ```shell
-$ cat MotherlyWolf.json | \
-    python -m osxcollector.output_filters.chrome.find_extensions
+$ python -m osxcollector.output_filters.chrome.find_extensions \
+         -i MotherlyWolf.json | \
+    jq 'select(.osxcollector_section=="chrome" and
+               .osxcollector_subsection=="extensions")'
 ```
 
-To see Chrome extensions:
+Usage:
 ```shell
-$ cat MotherlyWolf.json | \
-    python -m osxcollector.output_filters.chrome.find_extensions | \
-    jq 'select(.osxcollector_section=="chrome" and
-             .osxcollector_subsection=="extensions")'
+$ python -m osxcollector.output_filters.chrome.find_extensions -h
+usage: find_extensions.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ##### FirefoxExtensionsFilter
 `osxcollector.output_filters.firefox.find_extensions.FindExtensionsFilter` looks for extensions in the Firefox JSON files.
 
-Run it as:
+To run and see Firefox extensions:
 ```shell
-$ cat FlawlessPelican.json | \
-    python -m osxcollector.output_filters.firefox.find_extensions
+$ python -m osxcollector.output_filters.firefox.find_extensions \
+         -i FlawlessPelican.json | \
+    jq 'select(.osxcollector_section=="firefox" and
+               .osxcollector_subsection=="extensions")'
 ```
 
-To see Firefox extensions:
+Usage:
 ```shell
-$ cat FlawlessPelican.json | \
-    python -m osxcollector.output_filters.firefox.find_extensions | \
-    jq 'select(.osxcollector_section=="firefox" and
-             .osxcollector_subsection=="extensions")'
+$ python -m osxcollector.output_filters.firefox.find_extensions -h
+usage: find_extensions.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 #### Threat API Filters
@@ -448,21 +494,14 @@ Often an initial alert contains a domain or IP your analysts don't know anything
 
 The filter will ignore domains if they are in the blacklist named `domain_whitelist`. This helps to reduce churn and false positives.
 
-Run it as:
+Run it as and see what it found:
 ```shell
-$ cat NotchCherry.json | \
-    python -m osxcollector.output_filters.find_domains | \
+$ python -m osxcollector.output_filters.find_domains -i NotchCherry.json | \
     python -m osxcollector.output_filters.opendns.related_domains \
            -d dismalhedgehog.com -d fantasticrabbit.org \
-           -i 128.128.128.28
-```
-
-To see what it found:
-```shell
-$ jq 'select(has("osxcollector_related")) |
-      select(.osxcollector_related |
-             keys[] |
-             contains("domains"))'
+           -i 128.128.128.28 | \
+    jq 'select(has("osxcollector_related")) |
+        select(.osxcollector_related | keys[] | contains("domains"))'
 ```
 
 The results will look something like:
@@ -477,21 +516,53 @@ The results will look something like:
 }
 ```
 
+Usage:
+```shell
+$ python -m osxcollector.output_filters.opendns.related_domains -h
+usage: related_domains.py [-h] [-d INITIAL_DOMAINS] [-i INITIAL_IPS]
+                          [--related-domains-generations GENERATIONS]
+                          [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
+
+opendns.RelatedDomainsFilter:
+  -d INITIAL_DOMAINS, --domain INITIAL_DOMAINS
+                        [OPTIONAL] Suspicious domains to use in pivoting. May
+                        be specified more than once.
+  -i INITIAL_IPS, --ip INITIAL_IPS
+                        [OPTIONAL] Suspicious IP to use in pivoting. May be
+                        specified more than once.
+  --related-domains-generations GENERATIONS
+                        [OPTIONAL] How many generations of related domains to
+                        lookup with OpenDNS
+```
+
 ##### OpenDNS LookupDomainsFilter
 `osxcollector.output_filters.opendns.lookup_domains.LookupDomainsFilter` lookups domain reputation and threat information with the OpenDNS Umbrella API. It adds information about _suspicious_ domains to the output lines.
 
 The filter uses a heuristic to determine what is _suspicious_. It can create false positives but usually a download from a domain marked as _suspicious_ is a good lead.
 
-Run it as:
+Run it and see what was found:
 ```shell
-$ cat GladElegant.json | \
-    python -m osxcollector.output_filters.find_domains | \
-    python -m osxcollector.output_filters.opendns.lookup_domains
+$ python -m osxcollector.output_filters.find_domains -i GladElegant.json | \
+    python -m osxcollector.output_filters.opendns.lookup_domains | \
+    jq 'select(has("osxcollector_opendns"))'
 ```
 
-To see what it found:
+Usage:
 ```shell
-$ jq 'select(has("osxcollector_opendns"))'
+$ python -m osxcollector.output_filters.opendns.lookup_domains -h
+usage: lookup_domains.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ##### VirusTotal LookupDomainsFilter
@@ -499,68 +570,97 @@ $ jq 'select(has("osxcollector_opendns"))'
 
 The filter uses a heuristic to determine what is _suspicious_. It can create a lot of false positives but also provides good leads.
 
-Run it as:
+Run it and see what was found:
 ```shell
-$ cat PippinNightstar.json | \
-    python -m osxcollector.output_filters.find_domains | \
-    python -m osxcollector.output_filters.virustotal.lookup_domains
+$ python -m osxcollector.output_filters.find_domains -i PipinNightstar.json | \
+    python -m osxcollector.output_filters.virustotal.lookup_domains | \
+    jq 'select(has("osxcollector_vtdomain"))'
 ```
 
-To see what it found:
+Usage:
 ```shell
-$ jq 'select(has("osxcollector_vtdomain"))'
+$ python -m osxcollector.output_filters.virustotal.lookup_domains -h
+usage: lookup_domains.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ##### VirusTotal LookupHashesFilter
 `osxcollector.output_filters.virustotal.lookup_hashes.LookupHashesFilter` lookups hashes with the VirusTotal API. This basically finds anything VirusTotal knows about which is a huge time saver. There's pretty much no false positives here, but there's also no chance of detecting unknown stuff.
 
-Run it as:
-```
-$ cat PippinNightstar.json | \
-    python -m osxcollector.output_filters.virustotal.lookup_hashes
+Run it and see what was found:
+```shell
+$ python -m osxcollector.output_filters.virustotal.lookup_hashes \
+         -i FungalBuritto.json | \
+    jq 'select(has("osxcollector_vthash"))'
 ```
 
-To see what it found:
+Usage:
 ```shell
-$ jq 'select(has("osxcollector_vthash"))'
+$ python -m osxcollector.output_filters.virustotal.lookup_hashes -h
+usage: lookup_hashes.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ##### VirusTotal LookupURLsFilter
 `osxcollector.output_filters.virustotal.lookup_hashes.LookupURLsFilter` lookups URLs with the VirusTotal API. As this only looks up the reports, it may not find the reports for some unknown URLs.
 
-Run it as:
-```
-$ cat PippinNightstar.json | \
-    python -m osxcollector.output_filters.virustotal.lookup_urls
+Run it and see what was found:
+```shell
+$ python -m osxcollector.output_filters.virustotal.lookup_urls \
+         -i WutheringGreens.json | \
+    jq 'select(has("osxcollector_vturl"))'
 ```
 
-To see what it found:
+Usage
 ```shell
-$ jq 'select(has("osxcollector_vturl"))'
+$ python -m osxcollector.output_filters.virustotal.lookup_urls -h
+usage: lookup_urls.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 ###### Maximum resources per request
 Both VirusTotal LookupHashesFilter and LookupURLsFilter can save time by including in a single API request the reports for the multiple resources (hashes or URLs).
-As the number of the maximum resources in a request depends on whether you are using a Public or Private API key it is configurable in `osxcollector.yaml` file
-in `virustotal` section:
-```
+As the number of the maximum resources in a request depends on whether you are using a Public or Private API key it is configurable in `osxcollector.yaml` file in `virustotal` section:
+```yaml
 resources_per_req: 4
 ```
-
 
 ##### ShadowServer LookupHashesFilter
 `osxcollector.output_filters.shadowserver.lookup_hashes.LookupHashesFilter`
 lookups hashes with the ShadowServer bin-test API. This is sort of the opposite of a VirusTotal lookup and returns results when it sees the hashes of known good files. This helps raise confidence that a file is not malicious.
 
-Run it as:
-```
-$ cat ArkashKobiashi.json | \
-    python -m osxcollector.output_filters.shadowserver.lookup_hashes
+Run it and see what was found:
+```shell
+$ python -m osxcollector.output_filters.shadowserver.lookup_hashes \
+         -i ArkashKobiashi.json | \
+    jq 'select(has("osxcollector_shadowserver"))'
 ```
 
-To see what it found:
+Usage:
 ```shell
-$ jq 'select(has("osxcollector_shadowserver"))'
+$ python -m osxcollector.output_filters.shadowserver.lookup_hashes -h
+usage: lookup_hashes.py [-h] [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
 ```
 
 #### AnalyzeFilter - The One Filter to Rule Them All
@@ -568,8 +668,7 @@ $ jq 'select(has("osxcollector_shadowserver"))'
 
 Then _Very Readable Output Bot_ takes over and prints out an easy-to-digest, human-readable, nearly-English summary of what it found. It's basically equivalent to running:
 ```shell
-$ cat SlickApocalypse.json | \
-    python -m osxcollector.output_filters.chrome.find_extensions.FindExtensionsFilter | \
+$ python -m osxcollector.output_filters.chrome.find_extensions.FindExtensionsFilter -i SlickApocalypse.json | \
     python -m osxcollector.output_filters.firefox.find_extensions.FindExtensionsFilter | \
     python -m osxcollector.output_filters.find_domains | \
     python -m osxcollector.output_filters.shadowserver.lookup_hashes | \
@@ -592,6 +691,55 @@ $ cat SlickApocalypse.json | \
 and then letting a wise-cracking analyst explain the results to you. The _Very Readable Output Bot_ even suggests hashes and domains to add to blacklists.
 
 This thing is the real deal and our analysts don't even look at OSXCollector output until after they've run the `AnalyzeFilter`.
+
+Run it as:
+```shell
+$ python -m osxcollector.output_filters.analyze -i FullMonty.json
+```
+
+Usage:
+```shell
+$ python -m osxcollector.output_filters.analyze -h
+usage: analyze.py [-f FILE_TERMS] [-d INITIAL_DOMAINS] [-i INITIAL_IPS]
+                  [--related-domains-generations GENERATIONS] [-h] [--readout]
+                  [--no-opendns] [--no-virustotal] [--no-shadowserver] [-M]
+                  [--show-signature-chain] [--show-browser-ext]
+                  [--input-file INPUT_FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input-file INPUT_FILE
+                        [OPTIONAL] Path to OSXCollector output to read.
+                        Defaults to stdin otherwise.
+
+RelatedFilesFilter:
+  -f FILE_TERMS, --file-term FILE_TERMS
+                        [OPTIONAL] Suspicious terms to use in pivoting through
+                        file names. May be specified more than once.
+
+opendns.RelatedDomainsFilter:
+  -d INITIAL_DOMAINS, --domain INITIAL_DOMAINS
+                        [OPTIONAL] Suspicious domains to use in pivoting. May
+                        be specified more than once.
+  -i INITIAL_IPS, --ip INITIAL_IPS
+                        [OPTIONAL] Suspicious IP to use in pivoting. May be
+                        specified more than once.
+  --related-domains-generations GENERATIONS
+                        [OPTIONAL] How many generations of related domains to
+                        lookup with OpenDNS
+
+AnalyzeFilter:
+  --readout             [OPTIONAL] Skip the analysis and just output really
+                        readable analysis
+  --no-opendns          [OPTIONAL] Don\'t run OpenDNS filters
+  --no-virustotal       [OPTIONAL] Don\'t run VirusTotal filters
+  --no-shadowserver     [OPTIONAL] Don\'t run ShadowServer filters
+  -M, --monochrome      [OPTIONAL] Output monochrome analysis
+  --show-signature-chain
+                        [OPTIONAL] Output unsigned startup items and kexts.
+  --show-browser-ext    [OPTIONAL] Output the list of installed browser
+                        extensions.
+```
 
 ## Contributing to OSXCollector
 We encourage you to extend the functionality of OSXCollector to suit your needs.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Hashes files in the mail app directories:
  - `~/Library/Mail`
  - `~/Library/Mail Downloads`
 
-#### `full_hash` section
+##### `full_hash` section
 Hashes all the files on disk. All of 'em. This does not run by default. It must be triggered with:
 ```shell
 $ sudo osxcollector.py -s full_hash

--- a/README.md
+++ b/README.md
@@ -240,16 +240,16 @@ Hashes files in the mail app directories:
  - `~/Library/Mail`
  - `~/Library/Mail Downloads`
 
-## Basic Manual Analysis
-Forensic analysis is a bit of art and a bit of science. Every analyst will see a bit of a different story when reading the output from OSXCollector. That's part of what makes analysis fun.
-
-Generally, collection is performed on a target machine because something is hinky: anti-virus found a file it doesn't like, deep packet inspect observed a callout, endpoint monitoring noticed a new startup item. The details of this initial alert - a file path, a timestamp, a hash, a domain, an IP, etc. - that's enough to get going.
-
 #### `full_hash` section
 Hashes all the files on disk. All of 'em. This does not run by default. It must be triggered with:
 ```shell
 $ sudo osxcollector.py -s full_hash
 ```
+
+## Basic Manual Analysis
+Forensic analysis is a bit of art and a bit of science. Every analyst will see a bit of a different story when reading the output from OSXCollector. That's part of what makes analysis fun.
+
+Generally, collection is performed on a target machine because something is hinky: anti-virus found a file it doesn't like, deep packet inspect observed a callout, endpoint monitoring noticed a new startup item. The details of this initial alert - a file path, a timestamp, a hash, a domain, an IP, etc. - that's enough to get going.
 
 #### Timestamps
 Simply greping a few minutes before and after a timestamp works great:
@@ -363,8 +363,7 @@ This filter is great for figuring out how `evil_invoice.pdf` landed up on a mach
 
 To run and see related lines try:
 ```shell
-$ python -m osxcollector.output_filters.related_files -i CanisAsp.json \
-         -f '/foo/bar/baz' -f 'dingle' | \
+$ python -m osxcollector.output_filters.related_files -i CanisAsp.json -f '/foo/bar/baz' -f 'dingle' | \
     jq 'select(has("osxcollector_related")) | \
         select(.osxcollector_related | keys[] | contains("files"))'
 ```
@@ -419,8 +418,7 @@ optional arguments:
 
 To run and see Firefox browser history:
 ```shell
-$ python -m osxcollector.output_filters.firefox.sort_history \
-         -i CousingLobe.json | \
+$ python -m osxcollector.output_filters.firefox.sort_history -i CousingLobe.json | \
     jq 'select(.osxcollector_browser_history=="firefox")'
 ```
 
@@ -441,8 +439,7 @@ optional arguments:
 
 To run and see Chrome extensions:
 ```shell
-$ python -m osxcollector.output_filters.chrome.find_extensions \
-         -i MotherlyWolf.json | \
+$ python -m osxcollector.output_filters.chrome.find_extensions -i MotherlyWolf.json | \
     jq 'select(.osxcollector_section=="chrome" and
                .osxcollector_subsection=="extensions")'
 ```
@@ -464,8 +461,7 @@ optional arguments:
 
 To run and see Firefox extensions:
 ```shell
-$ python -m osxcollector.output_filters.firefox.find_extensions \
-         -i FlawlessPelican.json | \
+$ python -m osxcollector.output_filters.firefox.find_extensions -i FlawlessPelican.json | \
     jq 'select(.osxcollector_section=="firefox" and
                .osxcollector_subsection=="extensions")'
 ```
@@ -572,7 +568,7 @@ The filter uses a heuristic to determine what is _suspicious_. It can create a l
 
 Run it and see what was found:
 ```shell
-$ python -m osxcollector.output_filters.find_domains -i PipinNightstar.json | \
+$ python -m osxcollector.output_filters.find_domains -i PippinNightstar.json | \
     python -m osxcollector.output_filters.virustotal.lookup_domains | \
     jq 'select(has("osxcollector_vtdomain"))'
 ```
@@ -594,8 +590,7 @@ optional arguments:
 
 Run it and see what was found:
 ```shell
-$ python -m osxcollector.output_filters.virustotal.lookup_hashes \
-         -i FungalBuritto.json | \
+$ python -m osxcollector.output_filters.virustotal.lookup_hashes -i FungalBuritto.json | \
     jq 'select(has("osxcollector_vthash"))'
 ```
 
@@ -616,8 +611,7 @@ optional arguments:
 
 Run it and see what was found:
 ```shell
-$ python -m osxcollector.output_filters.virustotal.lookup_urls \
-         -i WutheringGreens.json | \
+$ python -m osxcollector.output_filters.virustotal.lookup_urls -i WutheringLows.json | \
     jq 'select(has("osxcollector_vturl"))'
 ```
 
@@ -646,8 +640,7 @@ lookups hashes with the ShadowServer bin-test API. This is sort of the opposite 
 
 Run it and see what was found:
 ```shell
-$ python -m osxcollector.output_filters.shadowserver.lookup_hashes \
-         -i ArkashKobiashi.json | \
+$ python -m osxcollector.output_filters.shadowserver.lookup_hashes -i ArkashKobiashi.json | \
     jq 'select(has("osxcollector_shadowserver"))'
 ```
 

--- a/osxcollector/output_filters/analyze.py
+++ b/osxcollector/output_filters/analyze.py
@@ -31,7 +31,7 @@ import simplejson
 
 from osxcollector.output_filters.base_filters.chain import ChainFilter
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 from osxcollector.output_filters.chrome.find_extensions import FindExtensionsFilter as ChromeExtensionsFilter
 from osxcollector.output_filters.chrome.sort_history import SortHistoryFilter as ChromeHistoryFilter
 from osxcollector.output_filters.find_blacklisted import FindBlacklistedFilter
@@ -39,7 +39,6 @@ from osxcollector.output_filters.find_domains import FindDomainsFilter
 from osxcollector.output_filters.firefox.find_extensions import FindExtensionsFilter as FirefoxExtensionsFilter
 from osxcollector.output_filters.firefox.sort_history import SortHistoryFilter as FirefoxHistoryFilter
 from osxcollector.output_filters.opendns.lookup_domains import LookupDomainsFilter as OpenDnsLookupDomainsFilter
-from osxcollector.output_filters.opendns.related_domains import DEFAULT_RELATED_DOMAINS_GENERATIONS
 from osxcollector.output_filters.opendns.related_domains import RelatedDomainsFilter as OpenDnsRelatedDomainsFilter
 from osxcollector.output_filters.related_files import RelatedFilesFilter
 from osxcollector.output_filters.shadowserver.lookup_hashes import LookupHashesFilter as ShadowServerLookupHashesFilter
@@ -55,60 +54,61 @@ class AnalyzeFilter(ChainFilter):
     effect the operations of the next filter.
     """
 
-    def __init__(self,
-                 initial_file_terms=None,
-                 initial_domains=None,
-                 initial_ips=None,
-                 related_domains_generations=DEFAULT_RELATED_DOMAINS_GENERATIONS,
-                 monochrome=False,
-                 no_shadowserver=False,
-                 no_opendns=False,
-                 no_virustotal=False,
-                 show_signature_chain=False,
-                 show_browser_ext=False
-                 ):
+    def __init__(self, no_opendns=False, no_virustotal=False, no_shadowserver=False, readout=False, **kwargs):
 
         filter_chain = []
 
-        filter_chain.append(ChromeExtensionsFilter())
-        filter_chain.append(FirefoxExtensionsFilter())
+        if not readout:
+            filter_chain.append(ChromeExtensionsFilter(**kwargs))
+            filter_chain.append(FirefoxExtensionsFilter(**kwargs))
 
-        filter_chain.append(FindDomainsFilter())
+            filter_chain.append(FindDomainsFilter(**kwargs))
 
-        # Do hash related lookups first. This is done first since hash lookup is not influenced
-        # by anything but other hash lookups.
-        if not no_shadowserver:
-            filter_chain.append(ShadowServerLookupHashesFilter())
-        if not no_virustotal:
-            filter_chain.append(VtLookupHashesFilter(lookup_when=lookup_when_not_in_shadowserver))
+            # Do hash related lookups first. This is done first since hash lookup is not influenced
+            # by anything but other hash lookups.
+            if not no_shadowserver:
+                filter_chain.append(ShadowServerLookupHashesFilter(**kwargs))
+            if not no_virustotal:
+                filter_chain.append(VtLookupHashesFilter(lookup_when=lookup_when_not_in_shadowserver, **kwargs))
 
-        # Find blacklisted stuff next. Finding blacklisted domains requires running FindDomainsFilter first.
-        filter_chain.append(FindBlacklistedFilter())
+            # Find blacklisted stuff next. Finding blacklisted domains requires running FindDomainsFilter first.
+            filter_chain.append(FindBlacklistedFilter(**kwargs))
 
-        # RelatedFilesFilter and OpenDnsRelatedDomainsFilter use command line args in addition to previous filter results to find
-        # lines of interest.
-        filter_chain.append(RelatedFilesFilter(initial_terms=initial_file_terms, when=find_related_when))
-        if not no_opendns:
-            filter_chain.append(OpenDnsRelatedDomainsFilter(initial_domains=initial_domains,
-                                                            initial_ips=initial_ips, related_when=find_related_when,
-                                                            generations=related_domains_generations))
+            # RelatedFilesFilter and OpenDnsRelatedDomainsFilter use command line args in addition to previous filter results to find
+            # lines of interest.
+            filter_chain.append(RelatedFilesFilter(when=find_related_when, **kwargs))
+            if not no_opendns:
+                filter_chain.append(OpenDnsRelatedDomainsFilter(related_when=find_related_when, **kwargs))
 
-        # Lookup threat info on suspicious and related stuff
-        if not no_virustotal:
-            filter_chain.append(OpenDnsLookupDomainsFilter(lookup_when=lookup_when_not_in_shadowserver))
-        if not no_opendns:
-            filter_chain.append(VtLookupDomainsFilter(lookup_when=lookup_domains_in_vt_when))
+            # Lookup threat info on suspicious and related stuff
+            if not no_virustotal:
+                filter_chain.append(OpenDnsLookupDomainsFilter(lookup_when=lookup_when_not_in_shadowserver, **kwargs))
+            if not no_opendns:
+                filter_chain.append(VtLookupDomainsFilter(lookup_when=lookup_domains_in_vt_when, **kwargs))
 
-        # Sort browser history for maximum pretty
-        filter_chain.append(FirefoxHistoryFilter())
-        filter_chain.append(ChromeHistoryFilter())
+            # Sort browser history for maximum pretty
+            filter_chain.append(FirefoxHistoryFilter(**kwargs))
+            filter_chain.append(ChromeHistoryFilter(**kwargs))
 
-        # Summarize what has happened
-        filter_chain.append(_OutputToFileFilter())
-        filter_chain.append(_VeryReadableOutputFilter(monochrome=monochrome, show_signature_chain=show_signature_chain,
-                                                      show_browser_ext=show_browser_ext))
+            # Summarize what has happened
+            filter_chain.append(_OutputToFileFilter(**kwargs))
 
-        super(AnalyzeFilter, self).__init__(filter_chain)
+        filter_chain.append(_VeryReadableOutputFilter(**kwargs))
+
+        super(AnalyzeFilter, self).__init__(filter_chain, **kwargs)
+
+    def _on_get_commandline_args(self):
+        parser = ArgumentParser()
+        group = parser.add_argument_group('AnalyzeFilter')
+        group.add_argument('--readout', dest='readout', action='store_true', default=False,
+                           help='[OPTIONAL] Skip the analysis and just output really readable analysis')
+        group.add_argument('--no-opendns', dest='no_opendns', action='store_true', default=False,
+                           help='[OPTIONAL] Don\'t run OpenDNS filters')
+        group.add_argument('--no-virustotal', dest='no_virustotal', action='store_true', default=False,
+                           help='[OPTIONAL] Don\'t run VirusTotal filters')
+        group.add_argument('--no-shadowserver', dest='no_shadowserver', action='store_true', default=False,
+                           help='[OPTIONAL] Don\'t run ShadowServer filters')
+        return parser
 
 
 def include_in_summary(blob):
@@ -155,8 +155,8 @@ def find_related_when(blob):
 
 class _OutputToFileFilter(OutputFilter):
 
-    def __init__(self):
-        super(_OutputToFileFilter, self).__init__()
+    def __init__(self, **kwargs):
+        super(_OutputToFileFilter, self).__init__(**kwargs)
         self._all_blobs = list()
 
     def filter_line(self, blob):
@@ -195,8 +195,14 @@ class _OutputToFileFilter(OutputFilter):
 
 class _VeryReadableOutputFilter(OutputFilter):
 
-    def __init__(self, monochrome=False, show_signature_chain=False, show_browser_ext=False):
-        super(_VeryReadableOutputFilter, self).__init__()
+    END_COLOR = '\033[0m'
+    SECTION_COLOR = '\033[1m'
+    BOT_COLOR = '\033[93m\033[1m'
+    KEY_COLOR = '\033[94m'
+    VAL_COLOR = '\033[32m'
+
+    def __init__(self, monochrome=False, show_signature_chain=False, show_browser_ext=False, **kwargs):
+        super(_VeryReadableOutputFilter, self).__init__(**kwargs)
         self._vthash = []
         self._vtdomain = []
         self._opendns = []
@@ -249,11 +255,17 @@ class _VeryReadableOutputFilter(OutputFilter):
 
         return None
 
-    END_COLOR = '\033[0m'
-    SECTION_COLOR = '\033[1m'
-    BOT_COLOR = '\033[93m\033[1m'
-    KEY_COLOR = '\033[94m'
-    VAL_COLOR = '\033[32m'
+    @classmethod
+    def get_commandline_args(cls):
+        parser = ArgumentParser()
+        group = parser.add_argument_group('_VeryReadableOutputFilter')
+        group.add_argument('-M', '--monochrome', dest='monochrome', action='store_true', default=False,
+                           help='[OPTIONAL] Output monochrome analysis')
+        group.add_argument('--show-signature-chain', dest='show_signature_chain', action='store_true', default=False,
+                           help='[OPTIONAL] Output unsigned startup items and kexts.')
+        group.add_argument('--show-browser-ext', dest='show_browser_ext', action='store_true', default=False,
+                           help='[OPTIONAL] Output the list of installed browser extensions.')
+        return parser
 
     def _write(self, msg, color=END_COLOR):
         if not self._monochrome:
@@ -435,49 +447,8 @@ class _VeryReadableOutputFilter(OutputFilter):
 
 
 def main():
-    parser = ArgumentParser()
-    parser.add_argument('-f', '--file-term', dest='file_terms', default=[], action='append',
-                        help='[OPTIONAL] Suspicious terms to use in pivoting through file names.  May be specified more than once.')
-    parser.add_argument('-d', '--domain', dest='domain_terms', default=[], action='append',
-                        help='[OPTIONAL] Suspicious domains to use for pivoting.  May be specified more than once.')
-    parser.add_argument('-i', '--ip', dest='ip_terms', default=[], action='append',
-                        help='[OPTIONAL] Suspicious IP to use for pivoting.  May be specified more than once.')
-    parser.add_argument('--related-domains-generations', dest='related_domains_generations', default=DEFAULT_RELATED_DOMAINS_GENERATIONS,
-                        help='[OPTIONAL] How many generations of related domains to lookup with OpenDNS')
-    parser.add_argument('--readout', dest='readout', action='store_true', default=False,
-                        help='[OPTIONAL] Skip the analysis and just output really readable analysis')
-    parser.add_argument('-M', '--monochrome', dest='monochrome', action='store_true', default=False,
-                        help='[OPTIONAL] Output monochrome analysis')
-    parser.add_argument('--no-opendns', dest='no_opendns', action='store_true', default=False,
-                        help='[OPTIONAL] Don\'t run OpenDNS filters')
-    parser.add_argument('--no-virustotal', dest='no_virustotal', action='store_true', default=False,
-                        help='[OPTIONAL] Don\'t run VirusTotal filters')
-    parser.add_argument('--no-shadowserver', dest='no_shadowserver', action='store_true', default=False,
-                        help='[OPTIONAL] Don\'t run ShadowServer filters')
-    parser.add_argument('--show-signature-chain', dest='show_signature_chain', action='store_true', default=False,
-                        help='[OPTIONAL] Output unsigned startup items and kexts.')
-    parser.add_argument('--show-browser-ext', dest='show_browser_ext', action='store_true', default=False,
-                        help='[OPTIONAL] Output the list of installed browser extensions.')
-    parser.add_argument('--input-file', dest='input_file', default=None,
-                        help='[OPTIONAL] Path to OSXCollector output to read. Defaults to stdin otherwise.')
+    run_filter_main(AnalyzeFilter)
 
-    args = parser.parse_args()
-
-    if not args.readout:
-        output_filter = AnalyzeFilter(initial_file_terms=args.file_terms, initial_domains=args.domain_terms,
-                                      initial_ips=args.ip_terms, related_domains_generations=args.related_domains_generations,
-                                      monochrome=args.monochrome, no_opendns=args.no_opendns, no_virustotal=args.no_virustotal,
-                                      no_shadowserver=args.no_shadowserver, show_signature_chain=args.show_signature_chain,
-                                      show_browser_ext=args.show_browser_ext)
-    else:
-        output_filter = _VeryReadableOutputFilter(monochrome=args.monochrome, show_signature_chain=args.show_signature_chain,
-                                                  show_browser_ext=args.show_browser_ext)
-
-    if args.input_file:
-        with(open(args.input_file, 'r')) as fp_in:
-            run_filter(output_filter, input_stream=fp_in)
-    else:
-        run_filter(output_filter)
 
 if __name__ == "__main__":
     main()

--- a/osxcollector/output_filters/base_filters/chain.py
+++ b/osxcollector/output_filters/base_filters/chain.py
@@ -91,21 +91,34 @@ class ChainFilter(OutputFilter):
 
         return filtered_lines
 
-    def get_commandline_args(self):
+    def get_argument_parser(self):
+        """Collects the ArgumentParsers from every OutputFilter in the chain.
+
+        Returns:
+            An `argparse.ArgumentParser`
+        """
         parsers_to_chain = []
 
         cur_link = self._head_of_chain
         while cur_link:
-            arg_parser = cur_link.get_commandline_args()
+            arg_parser = cur_link.get_argument_parser()
             if arg_parser:
                 parsers_to_chain.append(arg_parser)
             cur_link = cur_link._next_link
 
-        parser = self._on_get_commandline_args()
+        parser = self._on_get_argument_parser()
         if parser:
             parsers_to_chain.append(parser)
 
         if parsers_to_chain:
             return ArgumentParser(parents=parsers_to_chain, conflict_handler='resolve')
 
+        return None
+
+    def _on_get_argument_parser(self):
+        """Returns an ArgumentParser with arguments for just this OutputFilter (not the contained chained OutputFilters).
+
+        Returns:
+            An `argparse.ArgumentParser`
+        """
         return None

--- a/osxcollector/output_filters/base_filters/chain.py
+++ b/osxcollector/output_filters/base_filters/chain.py
@@ -2,6 +2,8 @@
 #
 # ChainFilter is a base class that passes each line through a chain of OutputFilters.
 #
+from argparse import ArgumentParser
+
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
 
 
@@ -13,7 +15,7 @@ class ChainFilter(OutputFilter):
     having to run `python -m FilterOne | python -m FilterTwo | python -m FilterThree`.
     """
 
-    def __init__(self, chain):
+    def __init__(self, chain, **kwargs):
         """Adds the property _next_link to each OutputFilter in the chain.
 
         Treating the chain as a linked list makes it easy to know which filter runs after the current filter.
@@ -22,7 +24,7 @@ class ChainFilter(OutputFilter):
         Args:
             chain: An enumerable of OutputFilters.
         """
-        super(ChainFilter, self).__init__()
+        super(ChainFilter, self).__init__(**kwargs)
 
         prev_link = None
         for cur_link in chain:
@@ -88,3 +90,22 @@ class ChainFilter(OutputFilter):
             filtered_lines.extend(final_lines)
 
         return filtered_lines
+
+    def get_commandline_args(self):
+        parsers_to_chain = []
+
+        cur_link = self._head_of_chain
+        while cur_link:
+            arg_parser = cur_link.get_commandline_args()
+            if arg_parser:
+                parsers_to_chain.append(arg_parser)
+            cur_link = cur_link._next_link
+
+        parser = self._on_get_commandline_args()
+        if parser:
+            parsers_to_chain.append(parser)
+
+        if parsers_to_chain:
+            return ArgumentParser(parents=parsers_to_chain, conflict_handler='resolve')
+
+        return None

--- a/osxcollector/output_filters/base_filters/threat_feed.py
+++ b/osxcollector/output_filters/base_filters/threat_feed.py
@@ -16,7 +16,7 @@ class ThreatFeedFilter(OutputFilter):
     It is assumed that the API uses an api_key stored in the config.
     """
 
-    def __init__(self, ioc_key, output_key, lookup_when=None, name_of_api_key=None):
+    def __init__(self, ioc_key, output_key, lookup_when=None, name_of_api_key=None, **kwargs):
         """Configure the ThreatFeedFilter.
 
         Args:
@@ -27,7 +27,7 @@ class ThreatFeedFilter(OutputFilter):
                 Use lookup_when to limit which IOCs are looked up.
             name_of_api_key: A string name of the key in the 'api_key' section of config.
         """
-        super(ThreatFeedFilter, self).__init__()
+        super(ThreatFeedFilter, self).__init__(**kwargs)
 
         if name_of_api_key:
             self._api_key = config_get_deep('api_key.{0}'.format(name_of_api_key))

--- a/osxcollector/output_filters/chrome/find_extensions.py
+++ b/osxcollector/output_filters/chrome/find_extensions.py
@@ -5,7 +5,7 @@
 #
 from osxcollector.osxcollector import DictUtils
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 
 
 class FindExtensionsFilter(OutputFilter):
@@ -17,8 +17,8 @@ class FindExtensionsFilter(OutputFilter):
     and then parse the heck out of the extensions.
     """
 
-    def __init__(self):
-        super(FindExtensionsFilter, self).__init__()
+    def __init__(self, **kwargs):
+        super(FindExtensionsFilter, self).__init__(**kwargs)
         self._new_lines = []
 
     def filter_line(self, blob):
@@ -48,7 +48,7 @@ class FindExtensionsFilter(OutputFilter):
 
 
 def main():
-    run_filter(FindExtensionsFilter())
+    run_filter_main(FindExtensionsFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/chrome/sort_history.py
+++ b/osxcollector/output_filters/chrome/sort_history.py
@@ -4,7 +4,7 @@
 # SortHistoryFilter creates a clean sorted Chrome browser history and tags lines with {'osxcollector_browser_history': 'chrome'}
 #
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 
 
 class SortHistoryFilter(OutputFilter):
@@ -16,8 +16,8 @@ class SortHistoryFilter(OutputFilter):
     for some snazzy browser history stuff.
     """
 
-    def __init__(self):
-        super(SortHistoryFilter, self).__init__()
+    def __init__(self, **kwargs):
+        super(SortHistoryFilter, self).__init__(**kwargs)
 
         self._visits_table = dict()
         self._urls_table = dict()
@@ -275,7 +275,7 @@ class SortHistoryFilter(OutputFilter):
 
 
 def main():
-    run_filter(SortHistoryFilter())
+    run_filter_main(SortHistoryFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/find_blacklisted.py
+++ b/osxcollector/output_filters/find_blacklisted.py
@@ -4,7 +4,7 @@
 # FindBlacklistedFilter adds 'osxcollector_blacklist' key to lines matching a blacklist.
 #
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 from osxcollector.output_filters.util.blacklist import create_blacklist
 from osxcollector.output_filters.util.config import config_get_deep
 
@@ -24,8 +24,8 @@ class FindBlacklistedFilter(OutputFilter):
         blacklist_is_domains - [OPTIONAL] interpret values as domains and do some smart regex and subdomain stuff with them
     """
 
-    def __init__(self):
-        super(FindBlacklistedFilter, self).__init__()
+    def __init__(self, **kwargs):
+        super(FindBlacklistedFilter, self).__init__(**kwargs)
         self._blacklists = self._init_blacklists()
 
     def _init_blacklists(self):
@@ -49,7 +49,7 @@ class FindBlacklistedFilter(OutputFilter):
 
 
 def main():
-    run_filter(FindBlacklistedFilter())
+    run_filter_main(FindBlacklistedFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/find_domains.py
+++ b/osxcollector/output_filters/find_domains.py
@@ -8,7 +8,7 @@ from urllib import unquote_plus
 from urlparse import urlsplit
 
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 from osxcollector.output_filters.exceptions import BadDomainError
 from osxcollector.output_filters.util.domains import clean_domain
 from osxcollector.output_filters.util.domains import expand_domain
@@ -23,8 +23,8 @@ class FindDomainsFilter(OutputFilter):
     threat feeds.
     """
 
-    def __init__(self):
-        super(FindDomainsFilter, self).__init__()
+    def __init__(self, **kwargs):
+        super(FindDomainsFilter, self).__init__(**kwargs)
         self._domains = set()
 
     def filter_line(self, blob):
@@ -99,7 +99,7 @@ class FindDomainsFilter(OutputFilter):
 
 
 def main():
-    run_filter(FindDomainsFilter())
+    run_filter_main(FindDomainsFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/firefox/find_extensions.py
+++ b/osxcollector/output_filters/firefox/find_extensions.py
@@ -5,7 +5,7 @@
 #
 from osxcollector.osxcollector import DictUtils
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 
 
 class FindExtensionsFilter(OutputFilter):
@@ -17,8 +17,8 @@ class FindExtensionsFilter(OutputFilter):
     and then parse the heck out of the extensions.
     """
 
-    def __init__(self):
-        super(FindExtensionsFilter, self).__init__()
+    def __init__(self, **kwargs):
+        super(FindExtensionsFilter, self).__init__(**kwargs)
         self._new_lines = []
 
     def filter_line(self, blob):
@@ -48,7 +48,7 @@ class FindExtensionsFilter(OutputFilter):
 
 
 def main():
-    run_filter(FindExtensionsFilter())
+    run_filter_main(FindExtensionsFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/firefox/sort_history.py
+++ b/osxcollector/output_filters/firefox/sort_history.py
@@ -6,7 +6,7 @@
 import copy
 
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 
 
 class SortHistoryFilter(OutputFilter):
@@ -18,8 +18,8 @@ class SortHistoryFilter(OutputFilter):
     for some snazzy browser history stuff.
     """
 
-    def __init__(self):
-        super(SortHistoryFilter, self).__init__()
+    def __init__(self, **kwargs):
+        super(SortHistoryFilter, self).__init__(**kwargs)
 
         self._visits_table = dict()
         self._places_table = dict()
@@ -83,7 +83,7 @@ class SortHistoryFilter(OutputFilter):
 
 
 def main():
-    run_filter(SortHistoryFilter())
+    run_filter_main(SortHistoryFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/opendns/lookup_domains.py
+++ b/osxcollector/output_filters/opendns/lookup_domains.py
@@ -4,7 +4,7 @@
 #
 from collections import namedtuple
 
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 from osxcollector.output_filters.base_filters.threat_feed import ThreatFeedFilter
 from osxcollector.output_filters.opendns.api import InvestigateApi
 from osxcollector.output_filters.util.blacklist import create_blacklist
@@ -66,9 +66,9 @@ class LookupDomainsFilter(ThreatFeedFilter):
         'threat_type'
     ]
 
-    def __init__(self, lookup_when=None):
+    def __init__(self, lookup_when=None, **kwargs):
         super(LookupDomainsFilter, self).__init__('osxcollector_domains', 'osxcollector_opendns',
-                                                  lookup_when=lookup_when, name_of_api_key='opendns')
+                                                  lookup_when=lookup_when, name_of_api_key='opendns', **kwargs)
         self._whitelist = create_blacklist(config_get_deep('domain_whitelist'))
 
     def _lookup_iocs(self, all_iocs):
@@ -220,7 +220,7 @@ class LookupDomainsFilter(ThreatFeedFilter):
 
 
 def main():
-    run_filter(LookupDomainsFilter())
+    run_filter_main(LookupDomainsFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/opendns/related_domains.py
+++ b/osxcollector/output_filters/opendns/related_domains.py
@@ -116,13 +116,13 @@ class RelatedDomainsFilter(OutputFilter):
 
         return self._all_blobs
 
-    def get_commandline_args(self):
+    def get_argument_parser(self):
         parser = ArgumentParser()
         group = parser.add_argument_group('opendns.RelatedDomainsFilter')
         group.add_argument('-d', '--domain', dest='initial_domains', default=[], action='append',
-                           help='[OPTIONAL] Suspicious domains to use for pivoting.  May be specified more than once.')
+                           help='[OPTIONAL] Suspicious domains to use in pivoting.  May be specified more than once.')
         group.add_argument('-i', '--ip', dest='initial_ips', default=[], action='append',
-                           help='[OPTIONAL] Suspicious IP to use for pivoting.  May be specified more than once.')
+                           help='[OPTIONAL] Suspicious IP to use in pivoting.  May be specified more than once.')
         group.add_argument('--related-domains-generations', dest='generations', default=DEFAULT_RELATED_DOMAINS_GENERATIONS,
                            help='[OPTIONAL] How many generations of related domains to lookup with OpenDNS')
         return parser

--- a/osxcollector/output_filters/related_files.py
+++ b/osxcollector/output_filters/related_files.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # RelatedFilesFilter finds files related to specific terms or file names.
@@ -9,7 +10,7 @@ import simplejson
 
 from osxcollector.osxcollector import DictUtils
 from osxcollector.output_filters.base_filters.output_filter import OutputFilter
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 
 
 class RelatedFilesFilter(OutputFilter):
@@ -21,7 +22,7 @@ class RelatedFilesFilter(OutputFilter):
     is discarded.
     """
 
-    def __init__(self, when=None, initial_terms=None):
+    def __init__(self, when=None, file_terms=None, **kwargs):
         super(RelatedFilesFilter, self).__init__()
         self._all_blobs = list()
         self._terms = set()
@@ -29,8 +30,8 @@ class RelatedFilesFilter(OutputFilter):
 
         self._when = when
 
-        if initial_terms:
-            for val in initial_terms:
+        if file_terms:
+            for val in file_terms:
                 self._create_terms(val)
 
     def _create_terms(self, val):
@@ -63,6 +64,13 @@ class RelatedFilesFilter(OutputFilter):
                     blob['osxcollector_related']['files'].append(term)
 
         return self._all_blobs
+
+    def get_commandline_args(self):
+        parser = ArgumentParser()
+        group = parser.add_argument_group('RelatedFilesFilter')
+        group.add_argument('-f', '--file-term', dest='file_terms', default=[], action='append',
+                           help='[OPTIONAL] Suspicious terms to use in pivoting through file names.  May be specified more than once.')
+        return parser
 
     @property
     def terms(self):
@@ -119,12 +127,7 @@ class RelatedFilesFilter(OutputFilter):
 
 
 def main():
-    parser = ArgumentParser()
-    parser.add_argument('-f', '--file-term', dest='file_terms', default=[], action='append',
-                        help='[OPTIONAL] Suspicious terms to use in pivoting through file names.  May be specified more than once.')
-    args = parser.parse_args()
-
-    run_filter(RelatedFilesFilter(initial_terms=args.file_terms))
+    run_filter_main(RelatedFilesFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/related_files.py
+++ b/osxcollector/output_filters/related_files.py
@@ -65,7 +65,7 @@ class RelatedFilesFilter(OutputFilter):
 
         return self._all_blobs
 
-    def get_commandline_args(self):
+    def get_argument_parser(self):
         parser = ArgumentParser()
         group = parser.add_argument_group('RelatedFilesFilter')
         group.add_argument('-f', '--file-term', dest='file_terms', default=[], action='append',

--- a/osxcollector/output_filters/shadowserver/lookup_hashes.py
+++ b/osxcollector/output_filters/shadowserver/lookup_hashes.py
@@ -5,7 +5,7 @@
 #
 import os.path
 
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
 from osxcollector.output_filters.base_filters.threat_feed import ThreatFeedFilter
 from osxcollector.output_filters.shadowserver.api import ShadowServerApi
 from osxcollector.output_filters.util.config import config_get_deep
@@ -15,8 +15,8 @@ class LookupHashesFilter(ThreatFeedFilter):
 
     """A class to lookup hashes using ShadowServer API."""
 
-    def __init__(self, lookup_when=None):
-        super(LookupHashesFilter, self).__init__('sha1', 'osxcollector_shadowserver', lookup_when=lookup_when)
+    def __init__(self, lookup_when=None, **kwargs):
+        super(LookupHashesFilter, self).__init__('sha1', 'osxcollector_shadowserver', lookup_when=lookup_when, **kwargs)
 
     def _lookup_iocs(self, all_iocs):
         """Looks up the ShadowServer info for a set of hashes.
@@ -44,7 +44,7 @@ class LookupHashesFilter(ThreatFeedFilter):
 
 
 def main():
-    run_filter(LookupHashesFilter())
+    run_filter_main(LookupHashesFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/virustotal/lookup_domains.py
+++ b/osxcollector/output_filters/virustotal/lookup_domains.py
@@ -3,9 +3,8 @@
 #
 # LookupDomainsFilter uses VirusTotal to lookup the values in 'osxcollector_domains' and add 'osxcollector_vtdomain' key.
 #
-from osxcollector.output_filters.base_filters.output_filter import run_filter
-from osxcollector.output_filters.base_filters. \
-    threat_feed import ThreatFeedFilter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
+from osxcollector.output_filters.base_filters.threat_feed import ThreatFeedFilter
 from osxcollector.output_filters.util.blacklist import create_blacklist
 from osxcollector.output_filters.util.config import config_get_deep
 from osxcollector.output_filters.virustotal.api import VirusTotalApi
@@ -15,9 +14,9 @@ class LookupDomainsFilter(ThreatFeedFilter):
 
     """A class to lookup hashes using VirusTotal API."""
 
-    def __init__(self, lookup_when=None):
+    def __init__(self, lookup_when=None, **kwargs):
         super(LookupDomainsFilter, self).__init__('osxcollector_domains', 'osxcollector_vtdomain',
-                                                  lookup_when=lookup_when, name_of_api_key='virustotal')
+                                                  lookup_when=lookup_when, name_of_api_key='virustotal', **kwargs)
         self._whitelist = create_blacklist(config_get_deep('domain_whitelist'))
 
     def _lookup_iocs(self, all_iocs):
@@ -120,7 +119,7 @@ class LookupDomainsFilter(ThreatFeedFilter):
 
 
 def main():
-    run_filter(LookupDomainsFilter())
+    run_filter_main(LookupDomainsFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/virustotal/lookup_hashes.py
+++ b/osxcollector/output_filters/virustotal/lookup_hashes.py
@@ -3,9 +3,8 @@
 #
 # LookupHashesFilter uses VirusTotal to lookup the values in 'sha2' and add 'osxcollector_vthash' key.
 #
-from osxcollector.output_filters.base_filters.output_filter import run_filter
-from osxcollector.output_filters.base_filters. \
-    threat_feed import ThreatFeedFilter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
+from osxcollector.output_filters.base_filters.threat_feed import ThreatFeedFilter
 from osxcollector.output_filters.util.config import config_get_deep
 from osxcollector.output_filters.virustotal.api import VirusTotalApi
 
@@ -14,10 +13,10 @@ class LookupHashesFilter(ThreatFeedFilter):
 
     """A class to lookup hashes using VirusTotal API."""
 
-    def __init__(self, lookup_when=None):
+    def __init__(self, lookup_when=None, **kwargs):
         super(LookupHashesFilter, self).__init__('sha2',
                                                  'osxcollector_vthash', lookup_when=lookup_when,
-                                                 name_of_api_key='virustotal')
+                                                 name_of_api_key='virustotal', **kwargs)
 
     def _lookup_iocs(self, all_iocs):
         """Caches the VirusTotal info for a set of hashes.
@@ -77,7 +76,7 @@ class LookupHashesFilter(ThreatFeedFilter):
 
 
 def main():
-    run_filter(LookupHashesFilter())
+    run_filter_main(LookupHashesFilter)
 
 
 if __name__ == "__main__":

--- a/osxcollector/output_filters/virustotal/lookup_urls.py
+++ b/osxcollector/output_filters/virustotal/lookup_urls.py
@@ -5,9 +5,8 @@
 #
 import re
 
-from osxcollector.output_filters.base_filters.output_filter import run_filter
-from osxcollector.output_filters.base_filters. \
-    threat_feed import ThreatFeedFilter
+from osxcollector.output_filters.base_filters.output_filter import run_filter_main
+from osxcollector.output_filters.base_filters.threat_feed import ThreatFeedFilter
 from osxcollector.output_filters.util.config import config_get_deep
 from osxcollector.output_filters.virustotal.api import VirusTotalApi
 
@@ -18,11 +17,11 @@ class LookupURLsFilter(ThreatFeedFilter):
 
     SCHEMES = re.compile('https?')
 
-    def __init__(self, lookup_when=None):
+    def __init__(self, lookup_when=None, **kwargs):
         lookup_when_url_scheme_matches = self._generate_lookup_when(lookup_when)
         super(LookupURLsFilter, self).__init__('LSQuarantineDataURLString', 'osxcollector_vturl',
                                                lookup_when=lookup_when_url_scheme_matches,
-                                               name_of_api_key='virustotal')
+                                               name_of_api_key='virustotal', **kwargs)
 
     def _generate_lookup_when(self, only_lookup_when):
         """Generates functions that checks whether the blob contains a valid URL
@@ -89,7 +88,7 @@ class LookupURLsFilter(ThreatFeedFilter):
 
 
 def main():
-    run_filter(LookupURLsFilter())
+    run_filter_main(LookupURLsFilter)
 
 
 if __name__ == "__main__":

--- a/tests/output_filters/related_files_test.py
+++ b/tests/output_filters/related_files_test.py
@@ -19,21 +19,21 @@ class RelatedFilesFilterTest(RunFilterTest):
     def teardown_outputfilter(self):
         self._output_filter = None
 
-    def _run_test(self, input_blobs=None, when=when_anytime, initial_terms=None, expected_terms=None,
+    def _run_test(self, input_blobs=None, when=when_anytime, file_terms=None, expected_terms=None,
                   expected_usernames=None, expected_is_related=None):
         """Created a RelateFilesFilter, calls run_test, and performs additional filter specific validation.
 
         Args:
             input_blob: An enumerable of dicts
             when: A callable when to init the RelatedFilesFilter with
-            initial_terms: An enumerable of strings to init the RelatedFilesFilter with
+            file_terms: An enumerable of strings to init the RelatedFilesFilter with
             expected_terms: The expected final value of RelatedFilesFilter.terms
             expected_usernames: The expected final value of RelatedFilesFilter.usernames
             expected_is_related: An enumerable of the expected value of 'osxcollector_related' for each output_blob
         """
 
         def create_related_files_filter():
-            self._output_filter = RelatedFilesFilter(when=when, initial_terms=initial_terms)
+            self._output_filter = RelatedFilesFilter(when=when, file_terms=file_terms)
             return self._output_filter
 
         output_blobs = self.run_test(create_related_files_filter, input_blobs=input_blobs)
@@ -51,32 +51,32 @@ class CreateTermsTest(RelatedFilesFilterTest):
     """Focuses on testing that terms are properly created."""
 
     def test_single_term(self):
-        initial_terms = ['one_word']
+        file_terms = ['one_word']
         expected = ['one_word']
-        self._run_test(initial_terms=initial_terms, expected_terms=expected)
+        self._run_test(file_terms=file_terms, expected_terms=expected)
 
     def test_multi_terms(self):
-        initial_terms = ['one_word', 'pants', 'face']
+        file_terms = ['one_word', 'pants', 'face']
         expected = ['one_word', 'pants', 'face']
-        self._run_test(initial_terms=initial_terms, expected_terms=expected)
+        self._run_test(file_terms=file_terms, expected_terms=expected)
 
     def test_split_terms(self):
-        initial_terms = ['/ivanlei/source/osxcollector']
+        file_terms = ['/ivanlei/source/osxcollector']
         expected = ['ivanlei', 'source', 'osxcollector']
-        self._run_test(initial_terms=initial_terms, expected_terms=expected)
+        self._run_test(file_terms=file_terms, expected_terms=expected)
 
     def test_whitelist_terms(self):
-        initial_terms = ['/Users/ivanlei/source/osxcollector', '/Users/ivanlei/virtual_envs/osxcollector/bin/python']
+        file_terms = ['/Users/ivanlei/source/osxcollector', '/Users/ivanlei/virtual_envs/osxcollector/bin/python']
         expected = ['ivanlei', 'source', 'osxcollector', 'virtual_envs']
-        self._run_test(initial_terms=initial_terms, expected_terms=expected)
+        self._run_test(file_terms=file_terms, expected_terms=expected)
 
     def test_whitelist_username_terms(self):
-        initial_terms = ['/Users/ivanlei/source/osxcollector', '/Users/ivanlei/virtual_envs/osxcollector/bin/python']
+        file_terms = ['/Users/ivanlei/source/osxcollector', '/Users/ivanlei/virtual_envs/osxcollector/bin/python']
         expected = ['source', 'osxcollector', 'virtual_envs']
         blob = {'osxcollector_username': 'ivanlei'}
         expected_usernames = ['ivanlei']
 
-        self._run_test(input_blobs=[blob], initial_terms=initial_terms, expected_terms=expected, expected_usernames=expected_usernames)
+        self._run_test(input_blobs=[blob], file_terms=file_terms, expected_terms=expected, expected_usernames=expected_usernames)
 
 
 class FindUserNamesTest(RelatedFilesFilterTest):
@@ -110,8 +110,8 @@ class RelatedFilesFilterTest(RelatedFilesFilterTest):
         expected_is_related = [
             {'files': ['magic_value']}
         ]
-        initial_terms = ['magic_value']
-        self._run_test(input_blobs=input_blobs, initial_terms=initial_terms, expected_is_related=expected_is_related)
+        file_terms = ['magic_value']
+        self._run_test(input_blobs=input_blobs, file_terms=file_terms, expected_is_related=expected_is_related)
 
     def test_multi_term(self):
         input_blobs = [
@@ -124,8 +124,8 @@ class RelatedFilesFilterTest(RelatedFilesFilterTest):
             {'files': ['value']},
             {'files': ['magic', 'value']}
         ]
-        initial_terms = ['magic', 'value']
-        self._run_test(input_blobs=input_blobs, initial_terms=initial_terms, expected_is_related=expected_is_related)
+        file_terms = ['magic', 'value']
+        self._run_test(input_blobs=input_blobs, file_terms=file_terms, expected_is_related=expected_is_related)
 
     def test_split_term(self):
         input_blobs = [
@@ -138,8 +138,8 @@ class RelatedFilesFilterTest(RelatedFilesFilterTest):
             {'files': ['value']},
             {'files': ['magic', 'value']}
         ]
-        initial_terms = ['magic/value']
-        self._run_test(input_blobs=input_blobs, initial_terms=initial_terms, expected_is_related=expected_is_related)
+        file_terms = ['magic/value']
+        self._run_test(input_blobs=input_blobs, file_terms=file_terms, expected_is_related=expected_is_related)
 
     def test_discover_term(self):
         input_blobs = [

--- a/tests/output_filters/run_filter_test.py
+++ b/tests/output_filters/run_filter_test.py
@@ -6,7 +6,7 @@ import simplejson
 import testify as T
 from mock import patch
 
-from osxcollector.output_filters.base_filters.output_filter import run_filter
+from osxcollector.output_filters.base_filters.output_filter import _run_filter
 
 
 class RunFilterTest(T.TestCase):
@@ -39,7 +39,7 @@ class RunFilterTest(T.TestCase):
             __
         ):
             output_filter = create_filter()
-            run_filter(output_filter)
+            _run_filter(output_filter)
             output_lines = [line for line in mock_stdout.getvalue().split('\n') if len(line)]
             output_blobs = [simplejson.loads(line) for line in output_lines]
 


### PR DESCRIPTION
Allow filters to specify their arguments in an `argparse.ArgumentParser`. Cleanup the default main method to understand how to read and apply command line arguments.
