### PR TITLE
Enforcing Python 2.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 project = osxcollector
-envlist = py
+envlist = py27
 
 [testenv]
 install_command = pip install --use-wheel {opts} {packages}
@@ -17,7 +17,7 @@ commands =
     coverage report -m
 
 [testenv:venv]
-envdir = venv-{[tox]project}
+envdir = venv_{[tox]project}
 commands =
 
 [flake8]


### PR DESCRIPTION
There were few lines that were not playing well with Python 2.6 (e.g. [set initialization](../blob/ef3d9b82def3defb679df7cea11479e585a6e87a/tests/osxcollector_dict_util_test.py#L26)).

This change should make sure that tox is always using Python 2.7 when executing the tests.