### PR TITLE
Renaming virtualenv directory to virtualenv_run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ venv:
 	tox -evenv
 
 clean:
-	rm -rf build/ dist/ osxcollector.egg-info/ .tox/ venv-osxcollector/
+	rm -rf build/ dist/ osxcollector.egg-info/ .tox/ virtualenv_run/
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -delete	
 

--- a/README.md
+++ b/README.md
@@ -285,9 +285,8 @@ Unlike `osxcollector.py` filters have dependencies that aren't already installed
 To setup a virtualenv for the first time use:
 ```shell
 $ sudo pip install virtualenv
-$ virtualenv --system-site-packages venv_osxcollector
-$ source ./venv_osxcollector/bin/activate
-$ pip install -r ./requirements-dev.txt
+$ make venv
+$ source virtualenv_run/bin/activate
 ```
 
 #### Filter Configuration

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     coverage report -m
 
 [testenv:venv]
-envdir = venv_{[tox]project}
+envdir = virtualenv_run
 commands =
 
 [flake8]


### PR DESCRIPTION
`README.md` mentioned creating `venv_osxcollector` while `tox.ini` had `venv-osxcollector` in the `venv` target.
I have decided to change it to standard `virtualenv_run` everywhere.