### PR TITLE
Added plist reading and parsing error handling

### DIFF
--- a/tests/data/plists/invalid_format.plist
+++ b/tests/data/plists/invalid_format.plist
@@ -1,0 +1,1 @@
+this is not a plist

--- a/tests/osxcollector_collector_test.py
+++ b/tests/osxcollector_collector_test.py
@@ -172,3 +172,26 @@ class CollectorTestCase(T.TestCase):
             mock_read_plist.assert_called_with(self.collector, plist_path)
             for recent in recents:
                 self.mock_log_dict.assert_any_call(recent)
+
+    def test_read_plist_non_existing(self):
+        plist = self.collector._read_plist('tests/data/plists/non_existing.plist')
+        T.assert_equals({}, plist)
+        self.mock_log_dict.assert_not_called()
+
+    def assert_read_plist_parse_error(self, plist_path):
+        error = 'Unable to parse plist: [The data couldn\xe2\x80\x99t be read because it isn\xe2\x80\x99t in the correct format.].' \
+            + ' plist_path[{0}]'.format(plist_path)
+        expected_log = {
+            'osxcollector_error': error
+        }
+        plist = self.collector._read_plist(plist_path)
+        T.assert_equals({}, plist)
+        self.mock_log_dict.assert_called_once_with(expected_log)
+
+    def test_read_plist_invalid_format(self):
+        plist_path = 'tests/data/plists/invalid_format.plist'
+        self.assert_read_plist_parse_error(plist_path)
+
+    def test_read_plist_empty(self):
+        plist_path = 'tests/data/plists/empty.plist'
+        self.assert_read_plist_parse_error(plist_path)


### PR DESCRIPTION
This change adds more robust error handling for the plist reading and parsing functions, which are native Objective-C calls using the Foundation package.
Also the obsolete [`Foundation.NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_`](https://developer.apple.com/library/prerelease/mac/documentation/Cocoa/Reference/Foundation/Classes/NSPropertyListSerialization_Class/index.html#//apple_ref/occ/clm/NSPropertyListSerialization/propertyListFromData:mutabilityOption:format:errorDescription:) was replaced by [`Foundation.NSPropertyListSerialization.propertyListWithData_options_format_error_`](https://developer.apple.com/library/prerelease/mac/documentation/Cocoa/Reference/Foundation/Classes/NSPropertyListSerialization_Class/index.html#//apple_ref/occ/clm/NSPropertyListSerialization/propertyListWithData:options:format:error:) as suggested on the [`NSPropertyListSerialization` reference page](https://developer.apple.com/library/prerelease/mac/documentation/Cocoa/Reference/Foundation/Classes/NSPropertyListSerialization_Class/index.html#//apple_ref/occ/clm/NSPropertyListSerialization/propertyListFromData:mutabilityOption:format:errorDescription:).

Error handling code retrieves the error message from the native [`NSError`](https://developer.apple.com/library/prerelease/mac/documentation/Cocoa/Reference/Foundation/Classes/NSError_Class/index.html#//apple_ref/doc/c_ref/NSError) object from which the description is retrieved using [`CFErrorCopyDescription`](https://developer.apple.com/library/prerelease/ios/documentation/CoreFoundation/Reference/CFErrorRef/index.html#//apple_ref/c/func/CFErrorCopyDescription) method.