### PR TITLE
Logging warning message rather than an error when the plist file is empty

### DIFF
--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -944,6 +944,9 @@ class Collector(object):
                 error_description = _decode_error_description(error)
                 Logger.log_error('Unable to read plist: [{0}]. plist_path[{1}]'.format(error_description, plist_path))
                 return default
+            if 0 == plist_nsdata.length():
+                Logger.log_warning('Empty plist. plist_path[{0}]'.format(plist_path))
+                return default
 
             plist_dictionary, _, error = Foundation.NSPropertyListSerialization.propertyListWithData_options_format_error_(
                 plist_nsdata, Foundation.NSPropertyListMutableContainers, None, None)

--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -935,6 +935,7 @@ class Collector(object):
             default = {}
 
         if not os.path.isfile(plist_path):
+            Logger.log_warning('plist file not found. plist_path[{0}]'.format(plist_path))
             return default
 
         try:

--- a/tests/osxcollector_collector_test.py
+++ b/tests/osxcollector_collector_test.py
@@ -178,20 +178,24 @@ class CollectorTestCase(T.TestCase):
         T.assert_equals({}, plist)
         self.mock_log_dict.assert_not_called()
 
-    def assert_read_plist_parse_error(self, plist_path):
-        error = 'Unable to parse plist: [The data couldn\xe2\x80\x99t be read because it isn\xe2\x80\x99t in the correct format.].' \
-            + ' plist_path[{0}]'.format(plist_path)
-        expected_log = {
-            'osxcollector_error': error
-        }
+    def assert_log(self, plist_path, expected_log):
         plist = self.collector._read_plist(plist_path)
         T.assert_equals({}, plist)
         self.mock_log_dict.assert_called_once_with(expected_log)
 
     def test_read_plist_invalid_format(self):
         plist_path = 'tests/data/plists/invalid_format.plist'
-        self.assert_read_plist_parse_error(plist_path)
+        error = 'Unable to parse plist: [The data couldn\xe2\x80\x99t be read because it isn\xe2\x80\x99t in the correct format.].' \
+            + ' plist_path[{0}]'.format(plist_path)
+        expected_log = {
+            'osxcollector_error': error
+        }
+        self.assert_log(plist_path, expected_log)
 
     def test_read_plist_empty(self):
         plist_path = 'tests/data/plists/empty.plist'
-        self.assert_read_plist_parse_error(plist_path)
+        warning = 'Empty plist. plist_path[{0}]'.format(plist_path)
+        expected_log = {
+            'osxcollector_warn': warning
+        }
+        self.assert_log(plist_path, expected_log)

--- a/tests/osxcollector_collector_test.py
+++ b/tests/osxcollector_collector_test.py
@@ -173,22 +173,16 @@ class CollectorTestCase(T.TestCase):
             for recent in recents:
                 self.mock_log_dict.assert_any_call(recent)
 
-    def test_read_plist_non_existing(self):
-        plist = self.collector._read_plist('tests/data/plists/non_existing.plist')
-        T.assert_equals({}, plist)
-        self.mock_log_dict.assert_not_called()
-
     def assert_log(self, plist_path, expected_log):
         plist = self.collector._read_plist(plist_path)
         T.assert_equals({}, plist)
         self.mock_log_dict.assert_called_once_with(expected_log)
 
-    def test_read_plist_invalid_format(self):
-        plist_path = 'tests/data/plists/invalid_format.plist'
-        error = 'Unable to parse plist: [The data couldn\xe2\x80\x99t be read because it isn\xe2\x80\x99t in the correct format.].' \
-            + ' plist_path[{0}]'.format(plist_path)
+    def test_read_plist_file_not_found(self):
+        plist_path = 'tests/data/plists/non_existing.plist'
+        warning = 'plist file not found. plist_path[{0}]'.format(plist_path)
         expected_log = {
-            'osxcollector_error': error
+            'osxcollector_warn': warning
         }
         self.assert_log(plist_path, expected_log)
 
@@ -197,5 +191,14 @@ class CollectorTestCase(T.TestCase):
         warning = 'Empty plist. plist_path[{0}]'.format(plist_path)
         expected_log = {
             'osxcollector_warn': warning
+        }
+        self.assert_log(plist_path, expected_log)
+
+    def test_read_plist_invalid_format(self):
+        plist_path = 'tests/data/plists/invalid_format.plist'
+        error = 'Unable to parse plist: [The data couldn\xe2\x80\x99t be read because it isn\xe2\x80\x99t in the correct format.].' \
+            + ' plist_path[{0}]'.format(plist_path)
+        expected_log = {
+            'osxcollector_error': error
         }
         self.assert_log(plist_path, expected_log)


### PR DESCRIPTION
1. Logging warning message rather than an error when the plist file is empty.
2. Logging warning message when the plist file cannot be found.