### PR TITLE
Ignore IOError thrown when an extended attribute is not found

### DIFF
--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -274,6 +274,8 @@ def _get_extended_attr(file_path, attr):
             return [xattr_val]
     except KeyError:
         pass  # ignore missing key in xattr
+    except IOError:
+        pass  # ignore not found attribute
     return None
 
 


### PR DESCRIPTION
`IOError` with a message `Attribute not found` is thrown when an extended attribute (e.g. where-froms) is not found for a particular file.
There was already a section catching `KeyError` but it seems that there should be also another one for `IOError`.