### PR TITLE
added kyphosis

### DIFF
--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -38,6 +38,10 @@ from numbers import Number
 from sqlite3 import connect
 from sqlite3 import OperationalError
 from traceback import extract_tb
+import macholib.MachO
+import struct
+import base64
+
 
 import Foundation
 import objc
@@ -291,6 +295,9 @@ def _get_file_info(file_path, log_xattr=False):
     md5_hash, sha1_hash, sha2_hash = '', '', ''
     mtime = ''
     ctime = ''
+    extra_data_check = ''
+    extra_data_found = False
+    
 
     if os.path.isfile(file_path):
         mtime = _datetime_to_string(datetime.fromtimestamp(os.path.getmtime(file_path)))
@@ -301,6 +308,17 @@ def _get_file_info(file_path, log_xattr=False):
         except CodeSignChecker.CodeSignCheckerError:
             signature_chain = []
 
+        #check for extradata
+        try:
+            extra_data_result = str(kyphosis(file_path, False).extra_data)
+            if extra_data_result == "{}":
+                extra_data_check = ''
+            else:
+            	extra_data_check = base64.b64encode(extra_data_result)
+                extra_data_found = True
+        except:
+            extra_data_check = '' 
+
         file_info = {
             'md5': md5_hash,
             'sha1': sha1_hash,
@@ -308,8 +326,11 @@ def _get_file_info(file_path, log_xattr=False):
             'file_path': file_path,
             'mtime': mtime,
             'ctime': ctime,
-            'signature_chain': signature_chain
+            'signature_chain': signature_chain,
+            'extra_data_check': extra_data_check,
+            'extra_data_found': extra_data_found,
         }
+
         if log_xattr:
             where_from = _get_where_froms(file_path)
             if where_from:
@@ -409,6 +430,7 @@ class CodeSignChecker(object):
 
     # OS X constants
     errSecSuccess = 0x0
+    kSecCSCheckAllArchitectures = 0x1
     kSecCSDefaultFlags = 0x0
     kSecCSDoNotValidateResources = 0x4
     kSecCSSigningInformation = 0x2
@@ -1605,6 +1627,140 @@ class LogFileArchiver(object):
         except Exception as compress_directory_e:
             debugbreak()
             Logger.log_exception(compress_directory_e)
+
+class kyphosis():
+
+    def __init__(self, someFile, writeFile=False):
+
+        self.someFile = someFile
+        self.extra_data_found = False
+        self.supportedfiles = ["\xca\xfe\xba\xbe",  # FAT
+                               "\xcf\xfa\xed\xfe",  # x86
+                               "\xce\xfa\xed\xfe"   # x86_64
+                               ]
+        #check if macho
+        self.dataoff = 0
+        self.datasize = 0
+        self.beginOffset = 0
+        self.endOffset = 0
+        self.fat_hdrs = {}
+        self.extra_data = {}
+        self.writeFile = writeFile
+
+        self.run()
+
+    def run(self):
+        if self.check_binary() is not True:
+            # print "Submitted file is not a MachO file"
+            return None
+
+        self.aFile = macholib.MachO.MachO(self.someFile)
+
+        if self.aFile.fat is None:
+            self.find_load_cmds()
+            self.check_macho_size()
+        else:
+            # Fat file
+            self.make_soap()
+
+        if self.extra_data_found is True:
+            return True
+        else:
+            return False
+
+    def make_soap(self):
+        # process Fat file
+        with open(self.someFile, 'r') as self.bin:
+            self.bin.read(4)
+            ArchNo = struct.unpack(">I", self.bin.read(4))[0]
+            for arch in range(ArchNo):
+                self.fat_hdrs[arch] = self.fat_header()
+            self.end_fat_hdr = self.bin.tell()
+            beginning = True
+            self.count = 0
+            for hdr, value in self.fat_hdrs.iteritems():
+                if beginning is True:
+                    self.beginOffset = self.end_fat_hdr
+                    self.endOffset = value['Offset']
+                    self.check_space()
+                    self.beginOffset = value['Size'] + value['Offset']
+                    beginning = False
+                    self.count += 1
+                    continue
+                self.endOffset = value['Offset']
+                self.check_space()
+                self.beginOffset = value['Size'] + value['Offset']
+                self.count += 1
+        # Check end of file
+        self.last_entry = self.beginOffset
+        self.check_macho_size()
+
+    def check_space(self):
+        self.bin.seek(self.beginOffset, 0)
+        self.empty_space = self.bin.read(self.endOffset - self.beginOffset)
+        if self.empty_space != len(self.empty_space) * "\x00":
+            #print "Found extra data in the Fat file slack space for " + self.someFile
+            self.extra_data_found = True
+            self.extra_data[self.count] = self.empty_space
+            if self.writeFile is True:
+                print "Writing to " + os.path.basename(self.someFile) + '.extra_data_section' + str(self.count)
+                with open(os.path.basename(self.someFile) + '.extra_data_section' + str(self.count), 'w') as h:
+                    h.write(self.empty_space)
+
+    def fat_header(self):
+        header = {}
+        header["CPU Type"] = struct.unpack(">I", self.bin.read(4))[0]
+        header["CPU SubType"] = struct.unpack(">I", self.bin.read(4))[0]
+        header["Offset"] = struct.unpack(">I", self.bin.read(4))[0]
+        header["Size"] = struct.unpack(">I", self.bin.read(4))[0]
+        header["Align"] = struct.unpack(">I", self.bin.read(4))[0]
+        return header
+
+    def check_binary(self):
+        with open(self.someFile, 'r') as f:
+            self.magicheader = f.read(4)
+            if self.magicheader in self.supportedfiles:
+                return True
+
+    def find_load_cmds(self):
+        for header in self.aFile.headers:
+            for command in header.commands:
+                if 'dataoff' in vars(command[1])['_objects_']:
+                    self._dataoff = vars(command[1])['_objects_']['dataoff']
+                    if 'datassize' in vars(command[1])['_objects_']:
+                        self._datasize = vars(command[1])['_objects_']['datassize']
+                    else:
+                        self._datasize = vars(command[1])['_objects_']['datasize']
+                    if self._dataoff > self.dataoff:
+                        self.dataoff = self._dataoff
+                        self.datasize = self._datasize
+                if 'stroff' in vars(command[1])['_objects_']:
+                    self._dataoff = vars(command[1])['_objects_']['stroff']
+                    self._datasize = vars(command[1])['_objects_']['strsize']
+                    if self._dataoff > self.dataoff:
+                        self.dataoff = self._dataoff
+                        self.datasize = self._datasize
+                if 'fileoff' in vars(command[1])['_objects_']:
+                    self._dataoff = vars(command[1])['_objects_']['fileoff']
+                    self._datasize = vars(command[1])['_objects_']['filesize']
+                    if self._dataoff > self.dataoff:
+                        self.dataoff = self._dataoff
+                        self.datasize = self._datasize
+
+        self.last_entry = int(self.datasize + self.dataoff)
+
+    def check_macho_size(self):
+        with open(self.someFile, 'r') as f:
+            if os.stat(self.someFile).st_size > self.last_entry:
+                #print "Found extra data at the end of file.. " + self.someFile
+                f.seek(self.last_entry, 0)
+                extra_data_end = f.read()
+                self.extra_data_found = True
+                self.extra_data['extra_data_end'] = extra_data_end
+                if self.writeFile is True:
+                    print "Writing to " + os.path.basename(self.someFile) + ".extra_data_end"
+                    with open(os.path.basename(self.someFile) + '.extra_data_end', 'w') as g:
+                        g.write(extra_data_end)
 
 
 def main():

--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -297,7 +297,6 @@ def _get_file_info(file_path, log_xattr=False):
     ctime = ''
     extra_data_check = ''
     extra_data_found = False
-    
 
     if os.path.isfile(file_path):
         mtime = _datetime_to_string(datetime.fromtimestamp(os.path.getmtime(file_path)))
@@ -308,16 +307,16 @@ def _get_file_info(file_path, log_xattr=False):
         except CodeSignChecker.CodeSignCheckerError:
             signature_chain = []
 
-        #check for extradata
+        # check for extradata
         try:
             extra_data_result = str(kyphosis(file_path, False).extra_data)
             if extra_data_result == "{}":
                 extra_data_check = ''
             else:
-            	extra_data_check = base64.b64encode(extra_data_result)
+                extra_data_check = base64.b64encode(extra_data_result)
                 extra_data_found = True
         except:
-            extra_data_check = '' 
+            extra_data_check = ''
 
         file_info = {
             'md5': md5_hash,
@@ -1628,6 +1627,7 @@ class LogFileArchiver(object):
             debugbreak()
             Logger.log_exception(compress_directory_e)
 
+
 class kyphosis():
 
     def __init__(self, someFile, writeFile=False):
@@ -1638,7 +1638,7 @@ class kyphosis():
                                "\xcf\xfa\xed\xfe",  # x86
                                "\xce\xfa\xed\xfe"   # x86_64
                                ]
-        #check if macho
+        # check if macho
         self.dataoff = 0
         self.datasize = 0
         self.beginOffset = 0
@@ -1699,7 +1699,6 @@ class kyphosis():
         self.bin.seek(self.beginOffset, 0)
         self.empty_space = self.bin.read(self.endOffset - self.beginOffset)
         if self.empty_space != len(self.empty_space) * "\x00":
-            #print "Found extra data in the Fat file slack space for " + self.someFile
             self.extra_data_found = True
             self.extra_data[self.count] = self.empty_space
             if self.writeFile is True:
@@ -1752,7 +1751,6 @@ class kyphosis():
     def check_macho_size(self):
         with open(self.someFile, 'r') as f:
             if os.stat(self.someFile).st_size > self.last_entry:
-                #print "Found extra data at the end of file.. " + self.someFile
                 f.seek(self.last_entry, 0)
                 extra_data_end = f.read()
                 self.extra_data_found = True


### PR DESCRIPTION
In this pull request, I add kyphosis, a script to inspect Mach-O and Fat files for what is not loaded into memory.  These artifacts bypass 'no-strict' checks and could be of interest to an investigator. This is enabled whether strict or no-strict checking is enabled.

Output is written to the json log using two parameters.
* Anything that is not loaded into memory is base64 encoded and stored in the ````extra_data_check```` parameter.
* If anything is found the ````extra_data_found```` parameter will be set to ````true````

A quick regex of ```extra_data_check\": true``` will find all output that has extra data that is not loaded in memory.

Standalone code is here if you would like to test: https://github.com/secretsquirrel/kyphosis