### PR TITLE
Fixed invalid number mappings for datetime strings

### DIFF
--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -355,11 +355,13 @@ def _normalize_val(val, key=None):
     :returns: A string
     """
     # If the key hints this is a timestamp, try to use some popular formats
-    if key and any([-1 != key.lower().find(hint) for hint in ['time', 'utc', 'date', 'accessed']]) and not 'times' in key.lower():
+    if key and any([hint in key.lower() for hint in ['time', 'utc', 'date', 'accessed']]):
         ts = _value_to_datetime(val)
-        if not ts:
-            ts = datetime.fromtimestamp(0)
-        return _datetime_to_string(ts)
+        # Known timestamp keys with values not conforming to heuristics are mapped to a default timestamp
+        if not ts and key in ['last_access_time', 'expires_utc', 'date_created', 'end_time']:
+            ts = datetime.fromtimestamp(1)
+        if ts:
+            return _datetime_to_string(ts)
 
     try:
         if isinstance(val, basestring):

--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -355,10 +355,11 @@ def _normalize_val(val, key=None):
     :returns: A string
     """
     # If the key hints this is a timestamp, try to use some popular formats
-    if key and any([-1 != key.lower().find(hint) for hint in ['time', 'utc', 'date', 'accessed']]):
+    if key and any([-1 != key.lower().find(hint) for hint in ['time', 'utc', 'date', 'accessed']]) and not 'times' in key.lower():
         ts = _value_to_datetime(val)
-        if ts:
-            return _datetime_to_string(ts)
+        if not ts:
+            ts = datetime.fromtimestamp(0)
+        return _datetime_to_string(ts)
 
     try:
         if isinstance(val, basestring):


### PR DESCRIPTION
This fixes GH-156, where timestamp keys whose values could not be correctly rendered to timestamp strings were ultimately mapped to their original Number types instead of string types. As described in the issue, the problem with this was that when later ingested by analytics frameworks like Elasticsearch, type conflicts could arise since some values were interpreted as longs and others as strings. The fix is to by default return a very early `datetime` if rendering fails. 