### PR TITLE
fix travis build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-language: objective-c
+language: generic
 os: osx
+osx_image: xcode9.3
 install:
-   - sudo pip install -r requirements-dev.txt
+   - pip2 install --user -r requirements-dev.txt
 script: make test
 deploy:
   provider: pypi

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ project = osxcollector
 envlist = py27
 
 [testenv]
-install_command = pip install --use-wheel {opts} {packages}
+install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements-dev.txt
 whitelist_externals = pyflakes
 


### PR DESCRIPTION
Modified Travis config file, in reference to python build issues on osx mentioned [here](https://github.com/travis-ci/travis-ci/issues/8829#issuecomment-348027200) and [here](https://github.com/travis-ci/travis-ci/issues/8829#issuecomment-348322979).
Modified tox config to remove deprecated "--use-wheel" flag.