### PR TITLE
Fix plist file search in packages

### DIFF
--- a/osxcollector/__init__.py
+++ b/osxcollector/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-__version__ = '1.11'
+__version__ = '1.12'

--- a/osxcollector/osxcollector.py
+++ b/osxcollector/osxcollector.py
@@ -784,20 +784,17 @@ class Collector(object):
             Logger.log_dict(file_info)
 
     def _should_walk(self, sub_dir_path):
-        return any([sub_dir_path.endswith(extension) for extension in ['.app', '.kext', '.osax', 'Contents']])
+        return any(sub_dir_path.endswith(extension) for extension in ('.app', '.kext', '.osax', 'Contents'))
 
     def _log_packages_in_dir(self, dir_path):
         """Log the packages in a directory"""
         plist_file = 'Info.plist'
-
-        walk = [(sub_dir_path, file_names) for sub_dir_path, _, file_names in os.walk(dir_path) if self._should_walk(sub_dir_path)]
+        walk = (
+            (sub_dir_path, file_names) for sub_dir_path, _, file_names in os.walk(dir_path)
+            if self._should_walk(sub_dir_path) and plist_file in file_names
+        )
         for sub_dir_path, file_names in walk:
-            if plist_file in file_names:
-                if sub_dir_path.endswith('Contents'):
-                    cfbundle_executable_path = 'MacOS'
-                else:
-                    cfbundle_executable_path = ''
-
+            cfbundle_executable_path = 'MacOS' if sub_dir_path.endswith('Contents') else ''
             plist_path = pathjoin(sub_dir_path, plist_file)
             plist = self._read_plist(plist_path)
             cfbundle_executable = plist.get('CFBundleExecutable')


### PR DESCRIPTION
As highlighted by @zestysoft in #167, the function collecting `Info.plist` files raised a lot of warnings. The reason is that the check for the existence of the file was ignored during the loop. This change fixes that and also avoids the memory and CPU expensive task of generating the `walk` list and uses a lazy iterator instead.